### PR TITLE
ensure consistent model after mutation

### DIFF
--- a/src/geff/metadata_schema.py
+++ b/src/geff/metadata_schema.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import yaml
 import zarr
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic.config import ConfigDict
 
 import geff
@@ -29,7 +29,7 @@ class GeffMetadata(BaseModel):
     """
 
     # this determines the title of the generated json schema
-    model_config = ConfigDict(title="geff_metadata")
+    model_config = ConfigDict(title="geff_metadata", validate_assignment=True)
 
     geff_version: str = Field(pattern=SUPPORTED_VERSIONS_REGEX)
     directed: bool
@@ -39,8 +39,8 @@ class GeffMetadata(BaseModel):
     axis_names: tuple[str, ...] | None = None
     axis_units: tuple[str, ...] | None = None
 
-    def model_post_init(self, *args, **kwargs):  # noqa D102
-        # Check spatial metadata only if position is provided
+    @model_validator(mode="after")
+    def _validate_model(self) -> GeffMetadata:
         if self.position_attr is not None:
             # Check that rois are there if position provided
             if self.roi_min is None or self.roi_max is None:
@@ -72,12 +72,12 @@ class GeffMetadata(BaseModel):
                     f" dimensions in roi ({ndim})"
                 )
         # If no position, check that other spatial metadata is not provided
-        else:
-            if any([self.roi_min, self.roi_max, self.axis_names, self.axis_units]):
-                raise ValueError(
-                    "Spatial metadata (roi_min, roi_max, axis_names or axis_units) provided without"
-                    " position_attr"
-                )
+        elif any([self.roi_min, self.roi_max, self.axis_names, self.axis_units]):
+            raise ValueError(
+                "Spatial metadata (roi_min, roi_max, axis_names or axis_units) provided without"
+                " position_attr"
+            )
+        return self
 
     def write(self, group: zarr.Group | Path):
         """Helper function to write GeffMetadata into the zarr geff group.

--- a/src/geff/metadata_schema.py
+++ b/src/geff/metadata_schema.py
@@ -41,6 +41,7 @@ class GeffMetadata(BaseModel):
 
     @model_validator(mode="after")
     def _validate_model(self) -> GeffMetadata:
+        # Check spatial metadata only if position is provided
         if self.position_attr is not None:
             # Check that rois are there if position provided
             if self.roi_min is None or self.roi_max is None:

--- a/tests/test_agnostic/test_metadata_schema.py
+++ b/tests/test_agnostic/test_metadata_schema.py
@@ -162,6 +162,24 @@ class TestMetadataModel:
         compare = GeffMetadata.read(zpath)
         assert compare == meta
 
+    def test_model_mutation(self):
+        """Test that invalid model mutations raise errors."""
+        meta = GeffMetadata(
+            geff_version="0.0.1",
+            directed=True,
+            position_attr="position",
+            roi_min=(0, 0, 0),
+            roi_max=(100, 100, 100),
+        )
+
+        meta.roi_max = (200, 200, 200)  # fine...
+
+        with pytest.raises(pydantic.ValidationError):
+            meta.roi_min = None
+
+        with pytest.raises(pydantic.ValidationError):
+            meta.position_attr = None
+
 
 def test_write_schema(tmp_path):
     schema_path = tmp_path / "schema.json"


### PR DESCRIPTION
this change makes it so that it's not possible to mutate a `GeffMetadata` instance into an invalid state