### PR TITLE
Use os.path.expanduser to support tildes in paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docs/schema/*
 
 # Pytest coverage local files
 .coverage*
+/.idea

--- a/src/geff/networkx/io.py
+++ b/src/geff/networkx/io.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import os
 import warnings
 from typing import TYPE_CHECKING
 
 import networkx as nx
 import numpy as np
 import zarr
-import os
+
 import geff
 import geff.utils
 from geff.metadata_schema import GeffMetadata

--- a/src/geff/networkx/io.py
+++ b/src/geff/networkx/io.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import networkx as nx
 import numpy as np
 import zarr
-
+import os
 import geff
 import geff.utils
 from geff.metadata_schema import GeffMetadata
@@ -236,6 +236,7 @@ def read_nx(path: Path | str, validate: bool = True) -> nx.Graph:
     """
     # zarr python 3 doesn't support Path
     path = str(path)
+    path = os.path.expanduser(path)
 
     # open zarr container
     if validate:

--- a/src/geff/utils.py
+++ b/src/geff/utils.py
@@ -25,7 +25,7 @@ def validate(path: str | Path):
 
     # zarr python 3 doesn't support Path
     path = str(path)
-
+    path = os.path.expanduser(path)
     graph = zarr.open(path, mode="r")
 
     # graph attrs validation


### PR DESCRIPTION
# Proposed Change

Use os.path.expanduser to support tildes in paths. Closes #118 

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)

Which topics does your change affect? Delete those that do not apply.
- `networkx` implementation

# Checklist

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly.
- [ ] If I changed the specification, I have checked that any validation functions and tests reflect the changes.
