### PR TITLE
Update pre-commit hooks and fix linting issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,9 @@ repos:
       - id: typos
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.3
+    rev: v0.12.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,20 +40,20 @@ dev = [
 ]
 docs = [
     "mkdocs-material",
-    "mkdocstrings[python]", 
+    "mkdocstrings[python]",
     "mkdocs-api-autonav",
     "mkdocs-include-markdown-plugin",
     "mike",
     "json-schema-for-humans",
-    "typing-extensions",  # Required for json-schema-for-humans
-    "ruff",  # to format the source code signatures
+    "typing-extensions",              # Required for json-schema-for-humans
+    "ruff",                           # to format the source code signatures
 ]
 bench = [
     { include-group = "test" },
     "pytest-benchmark",
     "tabulate",
     "pandas",
-    "typer"
+    "typer",
 ]
 
 
@@ -71,7 +71,7 @@ python = "3.12.*"
 default = { solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 build = { features = ["build"], solve-group = "default" }
-docs = { features = ["docs"], solve-group = "default"}
+docs = { features = ["docs"], solve-group = "default" }
 bench = { features = ["dev", "bench"], solve-group = "default" }
 
 [tool.pixi.tasks]
@@ -91,18 +91,20 @@ build = "*"
 build = "python -m build"
 
 [tool.pixi.feature.docs.tasks]
-preview-docs = {cmd = "mkdocs serve", depends-on = "schema-docs"}
+preview-docs = { cmd = "mkdocs serve", depends-on = "schema-docs" }
 schema-docs = "generate-schema-doc geff-schema.json docs/schema/schema.html"
 
 [project.urls]
 repository = "https://github.com/live-image-tracking-tools/geff"
 homepage = "https://github.com/live-image-tracking-tools/geff"
 
-# https://github.com/charliermarsh/ruff
+# https://docs.astral.sh/ruff/rules/
 [tool.ruff]
 line-length = 100
-target-version = "py38"
-# https://beta.ruff.rs/docs/rules/
+target-version = "py310"
+fix = true
+
+[tool.ruff.lint]
 extend-select = [
     "E",    # style errors
     "W",    # style warnings
@@ -114,7 +116,7 @@ extend-select = [
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
     "TID",  # tidy imports
-    "TCH",  # type checking
+    "TC",   # type checking
     "D102", # undocumented public method
     "D103", # undocumented public function
     "D300", # enforces triple double quotes on docstrings
@@ -122,11 +124,11 @@ extend-select = [
     "D417", # undocumented parameter
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]  # unused imports in init files
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"] # unused imports in init files
 "tests/*.py" = ["D"]
 "scripts/*.py" = ["D"]
 
@@ -184,4 +186,4 @@ extend-ignore-identifiers-re = ["(?i)ome"]
 # ]
 
 [project.entry-points.pytest11]
-geff = "geff._pytest_plugin" 
+geff = "geff._pytest_plugin"

--- a/src/geff/_pytest_plugin.py
+++ b/src/geff/_pytest_plugin.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import networkx as nx
 import numpy as np

--- a/src/geff/metadata_schema.py
+++ b/src/geff/metadata_schema.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import warnings
+from collections.abc import Sequence  # noqa: TC003
 from pathlib import Path
-from typing import Sequence
 
 import zarr
 from pydantic import BaseModel, Field, model_validator

--- a/src/geff/writer_helper.py
+++ b/src/geff/writer_helper.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import zarr

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -18,7 +18,7 @@ def big_graph():
 
     nodes = np.arange(N_NODES)  # int
     positions = np.random.uniform(size=(N_NODES, 4))  # float
-    for node, pos in zip(nodes, positions):
+    for node, pos in zip(nodes, positions, strict=False):
         t, z, y, x = pos.tolist()
         graph.add_node(node.item(), t=t, z=z, y=y, x=x)
 

--- a/tests/test_networkx/test_nx_basics.py
+++ b/tests/test_networkx/test_nx_basics.py
@@ -58,7 +58,7 @@ def test_read_write_no_spatial(tmp_path, node_dtype, node_prop_dtypes, edge_prop
 
     nodes = np.array([10, 2, 127, 4, 5], dtype=node_dtype)
     props = np.array([4, 9, 10, 2, 8], dtype=node_prop_dtypes["position"])
-    for node, pos in zip(nodes, props):
+    for node, pos in zip(nodes, props, strict=False):
         graph.add_node(node.item(), attr=pos)
 
     edges = np.array(
@@ -72,7 +72,7 @@ def test_read_write_no_spatial(tmp_path, node_dtype, node_prop_dtypes, edge_prop
     )
     scores = np.array([0.1, 0.2, 0.3, 0.4], dtype=edge_prop_dtypes["score"])
     colors = np.array([1, 2, 3, 4], dtype=edge_prop_dtypes["color"])
-    for edge, score, color in zip(edges, scores, colors):
+    for edge, score, color in zip(edges, scores, colors, strict=False):
         graph.add_edge(*edge.tolist(), score=score.item(), color=color.item())
 
     path = tmp_path / "rw_consistency.zarr/graph"

--- a/tests/test_networkx/test_nx_missing_attrs.py
+++ b/tests/test_networkx/test_nx_missing_attrs.py
@@ -19,7 +19,7 @@ def graph_sparse_node_props():
         [1, 7, 6],
     ]
     node_scores = [0.5, 0.2, None, None, 0.1]
-    for node, pos, score in zip(nodes, positions, node_scores):
+    for node, pos, score in zip(nodes, positions, node_scores, strict=False):
         t, y, x = pos
         if score is not None:
             graph.add_node(node, t=t, y=y, x=x, score=score)
@@ -36,7 +36,7 @@ def graph_sparse_edge_props():
         [2, 5],
     ]
     edge_scores = [0.1, None, 0.5]
-    for edge, score in zip(edges, edge_scores):
+    for edge, score in zip(edges, edge_scores, strict=False):
         if score is not None:
             graph.add_edge(edge[0], edge[1], score=score)
         else:


### PR DESCRIPTION
This makes a couple small changes to linting rules, and then reruns pre-commit:

1. adds `target-version = "py310"` to ruff rules, (matching the project min)
2. adds fix=true to ruff rules in pyproject (convenient when running ruff format in vscode)
3. puts ruff rules in a  `[tool.ruff.lint]` section (removing warnings from ruff when running ruff)
4. runs pre-commit, which makes some changes due to the higher target-version, along with the `UP` rule