### PR TITLE
Add name prop for node/edge ids

### DIFF
--- a/tests/test_agnostic/test_write_dicts.py
+++ b/tests/test_agnostic/test_write_dicts.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from geff.write_dicts import dict_props_to_arr
+from geff.write_dicts import _get_max_length_in_bytes, _to_padded_utf8_bytes, dict_props_to_arr
 
 
 @pytest.fixture
@@ -28,6 +28,9 @@ def test_dict_prop_to_arr(data, data_type, expected):
     print(props_dict)
     values, missing = props_dict[data_type]
     ex_values, ex_missing = expected
+    if "str" in data_type:
+        max_length = _get_max_length_in_bytes(ex_values)
+        ex_values = [_to_padded_utf8_bytes(v, max_length) for v in ex_values]
     ex_values = np.array(ex_values)
     ex_missing = np.array(ex_missing, dtype=bool) if ex_missing is not None else None
 


### PR DESCRIPTION
# Proposed Change
Add optional `name` prop for `nodes` and `edges`

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- New feature or enhancement
- Documentation update
- Tests

Which topics does your change affect? Delete those that do not apply.
- Specification

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [x] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).

## If you changed the specification
- [ ] I have checked that any validation functions and tests reflect the changes.
- [ ] I have updated the GeffMetadata and the json schema using `pixi run update-schema` if necessary.
- [x] I have updated docs/specification.md to reflect the change.
- [x] I have updated implementations to reflect the change. (This can happen in separate PRs on a feature branch, but must be complete before merging into main.)

## If you have added or changed an implementation
- [x] I wrote tests for the new implementation using standard fixtures supplied in conftest.py.
- [ ] I updated pyproject.toml with new dependencies if needed.
- [ ] I added a function to tests/bench.py to benchmark the new implementation.

# Further Comments
Reading/writing `str` in the `FixedLengthUTF32` dtype is not supported in [JZarr](https://jzarr.readthedocs.io) used in [geff-java](https://github.com/mastodon-sc/geff-java). In this PR, the `str` values are encoded in byte arrays with `utf-8` and stored in zarr array using `uint8`.