### PR TITLE
:bug: Remove duplicate ctc dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dev = [
     "ruff",
     "ipython",
     "types-PyYAML",
+    "spatial-graph",
+    "geff[ctc]"
 ]
 docs = [
     "mkdocs-material",
@@ -74,7 +76,7 @@ python = "3.12.*"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }
-dev = { features = ["dev", "ctc", "spatial-graph"], solve-group = "default" }
+dev = { features = ["dev", "ctc"], solve-group = "default" }
 build = { features = ["build"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
 bench = { features = ["dev", "bench"], solve-group = "default" }


### PR DESCRIPTION
# Proposed Change
Couldn't run pixi task update-json in the dev group because the ctc group was included twice, once as a dependency group and once as extras. Keep the extras, because we want users to install geff[ctc], similar to spatial graph.  

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Maintenance (e.g. dependencies, CI, releases, etc.)