### PR TITLE
Only check `path.exists` for local paths

### DIFF
--- a/src/geff/utils.py
+++ b/src/geff/utils.py
@@ -9,7 +9,26 @@ import zarr
 if TYPE_CHECKING:
     from zarr.storage import StoreLike
 
+from urllib.parse import urlparse
+
 from .metadata_schema import GeffMetadata
+
+
+def is_remote_url(path: str) -> bool:
+    """Returns True if the path is a remote URL (http, https, ftp, sftp), otherwise False.
+
+    Parameters
+    ----------
+    path : str
+        path to a local or remote resource
+
+    Returns
+    -------
+    bool
+        True if the path is a remote URL, False otherwise
+    """
+    parsed = urlparse(path)
+    return parsed.scheme in ("http", "https", "ftp", "sftp")
 
 
 def remove_tilde(store: StoreLike) -> StoreLike:
@@ -44,7 +63,7 @@ def validate(store: StoreLike):
     # Check if path exists for string/Path inputs
     if isinstance(store, str | Path):
         store_path = Path(store)
-        if not store_path.exists():
+        if not is_remote_url(str(store_path)) and not store_path.exists():
             raise ValueError(f"Path does not exist: {store}")
 
     # Open the zarr group from the store

--- a/tests/test_agnostic/test_utils.py
+++ b/tests/test_agnostic/test_utils.py
@@ -12,6 +12,11 @@ def test_validate(tmp_path):
     with pytest.raises(ValueError, match=r"Path does not exist: does-not-exist"):
         validate("does-not-exist")
 
+    # remote zarr path does not raise existence error
+    remote_path = "https://blah.com/test.zarr"
+    with pytest.raises(ValueError, match=r"store must be a zarr StoreLike"):
+        validate(remote_path)
+
     # Path exists but is not a zarr store
     non_zarr_path = tmp_path / "not-a-zarr"
     non_zarr_path.mkdir()


### PR DESCRIPTION
# Proposed Change
The current validator precludes the handling of remote GEFFs because it explicitly checks `path.exists`, which will always return `False` for a remote GEFF.

This PR omits that check for URLs that are parsed as remote using the builtin `urllib` library.

# Types of Changes
-  enhancement
- validators

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).