### PR TITLE
remove lingering Graphdict occurences

### DIFF
--- a/src/geff/geff_reader.py
+++ b/src/geff/geff_reader.py
@@ -79,7 +79,7 @@ class GeffReader:
 
         If no names are specified, then all properties will be loaded
 
-        Call `build` to get the output `GraphDict` with the loaded properties.
+        Call `build` to get the output `InMemoryGeff` with the loaded properties.
 
         Args:
             names (lists of str, optional): The names of the node properties to load. If
@@ -101,7 +101,7 @@ class GeffReader:
 
         If no names are specified, then all properties will be loaded
 
-        Call `build` to get the output `GraphDict` with the loaded properties.
+        Call `build` to get the output `InMemoryGeff` with the loaded properties.
 
         Args:
             names (lists of str, optional): The names of the edge properties to load. If
@@ -135,7 +135,7 @@ class GeffReader:
             of a subset of edge, where `edge_mask` is equal to True. It must be a 1D
             array of length number of edges.
         Returns:
-            GraphDict: A graph represented in graph dict format.
+            InMemoryGeff: A dictionary of in memory numpy arrays representing the graph.
         """
         nodes = np.array(self.nodes[node_mask.tolist() if node_mask is not None else ...])
         node_props: dict[str, PropDictNpArray] = {}
@@ -209,7 +209,8 @@ def read_to_memory(
             if None all properties will be loaded, defaults to None.
 
     Returns:
-        A networkx graph containing the graph that was stored in the geff file format
+        A InMemoryGeff object containing the graph as a TypeDict of in memory numpy arrays
+        (metadata, node_ids, edge_ids, node_props, edge_props)
     """
 
     file_reader = GeffReader(source, validate)

--- a/src/geff/rustworkx/io.py
+++ b/src/geff/rustworkx/io.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     import rustworkx as rx
     from zarr.storage import StoreLike
 
-    from geff.dict_representation import GraphDict
+    from geff.typing import InMemoryGeff
 
 
 def get_roi_rx(
@@ -158,14 +158,14 @@ def write_rx(
     metadata.write(group)
 
 
-def _ingest_dict_rx(graph_dict: GraphDict) -> rx.PyDiGraph | rx.PyGraph:
+def _ingest_dict_rx(graph_dict: InMemoryGeff) -> rx.PyDiGraph | rx.PyGraph:
     """
-    Convert a GraphDict to a rustworkx graph.
+    Convert a InMemoryGeff to a rustworkx graph.
     The graph will have a `to_rx_id_map` attribute that maps geff node ids
     to rustworkx node indices.
 
     Args:
-        graph_dict: The GraphDict to convert to a rustworkx graph.
+        graph_dict: The InMemoryGeff to convert to a rustworkx graph.
 
     Returns:
         rx.PyGraph: A rustworkx graph.


### PR DESCRIPTION
Only textual changes: 
- renaiming `GraphDict` variables to `InMemoryGeff`
- changes some doc strings