### PR TITLE
remove docs benchmarks step

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -69,28 +69,3 @@ jobs:
             :---:
             | <p></p> :rocket: View preview at <br> ${{ steps.preview-step.outputs.preview-url }} <br><br>
             | <h6>Built to branch [`gh-pages`](${{ github.server_url }}/${{ github.repository }}/tree/gh-pages) at ${{ steps.preview-step.outputs.action-start-time }}. <br> Preview will be ready when the [GitHub Pages deployment](${{ github.server_url }}/${{ github.repository }}/deployments) is complete. <br><br> </h6>
-
-
-  benchmark:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Report benchmarks on gh-pages
-    runs-on: ubuntu-latest
-    needs:
-      - build-docs
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-      - name: Run benchmark
-        run: uv run --group bench pytest tests/bench.py --benchmark-json output.json
-
-      - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Python Benchmark with pytest-benchmark
-          tool: "pytest"
-          output-file-path: output.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          benchmark-data-dir-path: bench/


### PR DESCRIPTION
The removes the gh-pages benchmarks task.  @msschwartz21, if you'd like me to add a link to the codspeed dashboard, let me know where in the docs you want it to go