### PR TITLE
Update affine model to store numpy array directly, and provide schema hints

### DIFF
--- a/geff-schema.json
+++ b/geff-schema.json
@@ -1,11 +1,18 @@
 {
   "$defs": {
     "Affine": {
-      "description": "Affine transformation class following scipy conventions.\n\nInternally stores transformations as homogeneous coordinate matrices (N+1, N+1).\nThe transformation matrix follows scipy.ndimage.affine_transform convention\nwhere the matrix maps output coordinates to input coordinates (inverse/pull transformation).\n\nFor a point p_out in output space, the corresponding input point p_in is computed as:\np_in_homo = matrix @ p_out_homo\nwhere p_out_homo = [p_out; 1] and p_in = p_in_homo[:-1]\n\nAttributes:\n    matrix: Homogeneous transformation matrix as list of lists (ndim+1, ndim+1)",
+      "description": "Affine transformation matrix following scipy conventions.\n\nInternally stores transformations as homogeneous coordinate matrices (N+1, N+1).\nThe transformation matrix follows scipy.ndimage.affine_transform convention\nwhere the matrix maps output coordinates to input coordinates (inverse/pull transformation).\n\nFor a point p_out in output space, the corresponding input point p_in is computed as:\np_in_homo = matrix @ p_out_homo\nwhere p_out_homo = [p_out; 1] and p_in = p_in_homo[:-1]\n\nAttributes:\n    matrix (np.ndarray) : square, homogeneous transformation matrix (ndim+1, ndim+1)",
       "properties": {
         "matrix": {
-          "description": "Homogeneous transformation matrix as list of lists (ndim+1, ndim+1)",
-          "title": "Matrix"
+          "description": "Homogeneous transformation matrix (ndim+1, ndim+1)",
+          "items": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "title": "Matrix",
+          "type": "array"
         }
       },
       "required": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ source = ["src/geff"]
 omit = ["*/__init__.py"]
 
 [tool.typos.default]
-extend-ignore-identifiers-re = ["(?i)ome"]
+extend-ignore-identifiers-re = ["(?i)ome", "ser"]
 
 [project.scripts]
 geff = "geff._cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = ['version']
 dependencies = [
     "typer>=0.14.0",
     "zarr>=2.18,<4",
-    "pydantic>=2.11",
+    "pydantic>=2.9",
     "networkx>=3.2.1",
     "numpy>=1.24",
     "numpy>=1.26; python_version >= '3.12'",
@@ -74,7 +74,7 @@ docs = [
 ]
 bench = [
     { include-group = "test" },
-    "pytest-codspeed",
+    "pytest-codspeed>=4.0.0",
     "geff[rx, spatial-graph]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = ['version']
 dependencies = [
     "typer>=0.14.0",
     "zarr>=2.18,<4",
-    "pydantic>=2.9",
+    "pydantic>=2.11",
     "networkx>=3.2.1",
     "numpy>=1.24",
     "numpy>=1.26; python_version >= '3.12'",

--- a/src/geff/affine.py
+++ b/src/geff/affine.py
@@ -1,19 +1,68 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, GetCoreSchemaHandler, model_validator
+from pydantic_core import core_schema
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from numpy.typing import NDArray
+    from numpy.typing import DTypeLike, NDArray
+
+
+def _validate_tform(val: Any) -> np.ndarray:
+    try:
+        arr = np.asarray(val, dtype=float)
+    except Exception as e:
+        raise ValueError(f"Matrix must be convertible to numpy array: {e}") from e
+
+    if arr.ndim != 2:
+        raise ValueError(f"Matrix must be 2D, got {arr.ndim}D")
+
+    nr, nc = arr.shape
+    if nr != nc:
+        raise ValueError(f"Matrix must be square, got shape {arr.shape}")
+    if nr < 2:
+        raise ValueError(
+            f"Matrix must be at least 2x2 for homogeneous coordinates, got {arr.shape}"
+        )
+
+    # Check that bottom row is [0, 0, ..., 1]
+    expected_bottom_row = [0.0] * (nc - 1) + [1.0]
+    if not np.allclose(arr[-1], expected_bottom_row):
+        raise ValueError(
+            f"Bottom row of homogeneous matrix must be {expected_bottom_row}, got {arr[-1]}"
+        )
+
+    return arr
+
+
+class TFormMeta:
+    """Pydantic-compatible 4x4 numpy array."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        list_of_float = core_schema.list_schema(core_schema.float_schema())
+        list_of_list_of_float = core_schema.list_schema(list_of_float)
+        return core_schema.no_info_before_validator_function(
+            _validate_tform,
+            core_schema.is_instance_schema(np.ndarray),
+            # this is the schema for the input (i.e. "validation" mode)
+            json_schema_input_schema=list_of_list_of_float,
+            # this is the schema for the output (i.e. "serialization" mode)
+            serialization=core_schema.plain_serializer_function_set_schema(
+                np.ndarray.tolist,
+                return_schema=list_of_list_of_float,
+            ),
+        )
 
 
 class Affine(BaseModel):
-    """
-    Affine transformation class following scipy conventions.
+    """Affine transformation matrix following scipy conventions.
 
     Internally stores transformations as homogeneous coordinate matrices (N+1, N+1).
     The transformation matrix follows scipy.ndimage.affine_transform convention
@@ -24,55 +73,31 @@ class Affine(BaseModel):
     where p_out_homo = [p_out; 1] and p_in = p_in_homo[:-1]
 
     Attributes:
-        matrix: Homogeneous transformation matrix as list of lists (ndim+1, ndim+1)
+        matrix (np.ndarray) : square, homogeneous transformation matrix (ndim+1, ndim+1)
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    matrix: Any = Field(
-        ..., description="Homogeneous transformation matrix as list of lists (ndim+1, ndim+1)"
+    matrix: Annotated[np.ndarray, TFormMeta] = Field(
+        ...,
+        description="Homogeneous transformation matrix (ndim+1, ndim+1)",
     )
 
-    @model_validator(mode="after")
-    def validate_matrix(self) -> Affine:
-        """Validate that matrix is a proper homogeneous transformation matrix.
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_input(cls, v: Any) -> dict:
+        # if a numpy array or list is provided directly
+        # assign it to the matrix (as a convenience)
+        if isinstance(v, np.ndarray | list):
+            v = {"matrix": v}
+        return v
 
-        Converts to list of lists format.
-        """
-        # Convert input to numpy array for validation
-        try:
-            matrix_array = np.asarray(self.matrix, dtype=float)
-        except (ValueError, TypeError) as e:
-            raise ValueError(f"Matrix must be convertible to numpy array: {e}") from e
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+        """Convert the transform to a numpy array."""
+        return self.matrix.astype(dtype)
 
-        if matrix_array.ndim != 2:
-            raise ValueError(f"Matrix must be 2D, got {matrix_array.ndim}D")
-
-        if matrix_array.shape[0] != matrix_array.shape[1]:
-            raise ValueError(f"Matrix must be square, got shape {matrix_array.shape}")
-
-        if matrix_array.shape[0] < 2:
-            raise ValueError(
-                f"Matrix must be at least 2x2 for homogeneous coordinates, got {matrix_array.shape}"
-            )
-
-        # Check that bottom row is [0, 0, ..., 1]
-        expected_bottom_row = np.zeros(matrix_array.shape[1])
-        expected_bottom_row[-1] = 1.0
-
-        if not np.allclose(matrix_array[-1, :], expected_bottom_row):
-            raise ValueError(
-                f"Bottom row of homogeneous matrix must be [0, 0, ..., 1], "
-                f"got {matrix_array[-1, :]}"
-            )
-
-        # Convert to list of lists for storage
-        self.matrix = matrix_array.tolist()
-        return self
-
-    def numpy(self) -> NDArray[np.floating]:
-        """Convert the stored list of lists matrix to numpy array."""
-        return np.array(self.matrix, dtype=float)
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Affine):
+            return NotImplemented
+        return np.array_equal(self.matrix, value.matrix)
 
     @property
     def ndim(self) -> int:
@@ -82,14 +107,12 @@ class Affine(BaseModel):
     @property
     def linear_matrix(self) -> NDArray[np.floating]:
         """Extract the linear transformation part (ndim, ndim)."""
-        matrix_array = self.numpy()
-        return matrix_array[:-1, :-1].copy()
+        return self.matrix[:-1, :-1].copy()
 
     @property
     def offset(self) -> NDArray[np.floating]:
         """Extract the translation offset (ndim,)."""
-        matrix_array = self.numpy()
-        return matrix_array[:-1, -1].copy()
+        return self.matrix[:-1, -1].copy()
 
     def transform_points(self, points: NDArray[np.floating]) -> NDArray[np.floating]:
         """
@@ -118,8 +141,7 @@ class Affine(BaseModel):
         points_homo = np.concatenate([points_flat, ones], axis=1)
 
         # Transform using numpy conversion
-        matrix_array = self.numpy()
-        result_homo = (matrix_array @ points_homo.T).T
+        result_homo = (self.matrix @ points_homo.T).T
 
         # Extract non-homogeneous coordinates
         result = result_homo[:, :-1]

--- a/src/geff/affine.py
+++ b/src/geff/affine.py
@@ -54,7 +54,7 @@ class TFormMeta:
             # this is the schema for the input (i.e. "validation" mode)
             json_schema_input_schema=list_of_list_of_float,
             # this is the schema for the output (i.e. "serialization" mode)
-            serialization=core_schema.plain_serializer_function_set_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
                 np.ndarray.tolist,
                 return_schema=list_of_list_of_float,
             ),

--- a/src/geff/affine.py
+++ b/src/geff/affine.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Annotated, Any
 
 import numpy as np
-from pydantic import BaseModel, Field, GetCoreSchemaHandler, model_validator, version
+from pydantic import BaseModel, Field, GetCoreSchemaHandler, model_validator
 from pydantic_core import core_schema
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from numpy.typing import DTypeLike, NDArray
-
-
-PYDANTIC_211 = tuple(int(x) for x in version.VERSION.split(".")[:2]) >= (2, 11)
 
 
 def _validate_tform(val: Any) -> np.ndarray:
@@ -52,22 +49,16 @@ class TFormMeta:
         list_of_float = core_schema.list_schema(core_schema.float_schema())
         list_of_list_of_float = core_schema.list_schema(list_of_float)
 
-        if PYDANTIC_211:
-            # this is the schema for the input (i.e. "validation" mode)
-            # only available in Pydantic 2.11+
-            kwargs = {"json_schema_input_schema": list_of_list_of_float}
-        else:
-            kwargs = {}
-
         return core_schema.no_info_before_validator_function(
             _validate_tform,
             core_schema.is_instance_schema(np.ndarray),
+            # this is the schema for the input (i.e. "validation" mode)
+            json_schema_input_schema=list_of_list_of_float,
             # this is the schema for the output (i.e. "serialization" mode)
             serialization=core_schema.plain_serializer_function_ser_schema(
                 np.ndarray.tolist,
                 return_schema=list_of_list_of_float,
             ),
-            **kwargs,  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_agnostic/test_affine.py
+++ b/tests/test_agnostic/test_affine.py
@@ -133,13 +133,7 @@ class TestAffineTransformation:
     def test_scaling_transformation_2d(self):
         """Test scaling transformation in 2D."""
         # Note: scipy convention - inverse scaling for pull transform
-        matrix = np.array(
-            [
-                [0.5, 0, 0],  # Scale by 1/0.5 = 2 in x
-                [0, 0.25, 0],  # Scale by 1/0.25 = 4 in y
-                [0, 0, 1],
-            ]
-        )
+        matrix = np.diag([0.5, 0.25, 1])  # Scale by 2 in x, 4 in y
         affine = Affine(matrix=matrix)
 
         points = np.array([[2, 4]])

--- a/tests/test_agnostic/test_metadata_schema.py
+++ b/tests/test_agnostic/test_metadata_schema.py
@@ -316,9 +316,6 @@ class TestAffineTransformation:
         with pytest.raises(
             ValueError, match="Affine transformation matrix must have 3 dimensions, got 2"
         ):
-            # Homogeneous matrix of a 2D affine transformation
-            matrix = np.diag([1.0, 1.0, 1.0])
-            affine = Affine(matrix=matrix)
             GeffMetadata(
                 geff_version="0.1.0",
                 directed=True,
@@ -327,7 +324,8 @@ class TestAffineTransformation:
                     {"name": "y", "type": "space", "unit": "micrometer"},
                     {"name": "z", "type": "space", "unit": "micrometer"},
                 ],
-                affine=affine,
+                # Homogeneous matrix of a 2D affine transformation
+                affine=np.eye(3),
             )
 
     def test_affine_serialization_with_metadata(self, tmp_path):

--- a/tests/test_agnostic/test_metadata_schema.py
+++ b/tests/test_agnostic/test_metadata_schema.py
@@ -392,8 +392,8 @@ pydantic_version = tuple(int(x) for x in pydantic.__version__.split(".")[:2])
 
 
 @pytest.mark.skipif(
-    pydantic_version < (2, 10),
-    reason="Schema output was different in pydantic < 2.10",
+    pydantic_version < (2, 11),
+    reason="Schema generation requires pydantic >= 2.11",
 )
 def test_schema_file_updated(pytestconfig: pytest.Config) -> None:
     """Ensure that geff-schema.json at the repo root is up to date.

--- a/tests/test_agnostic/test_metadata_schema.py
+++ b/tests/test_agnostic/test_metadata_schema.py
@@ -388,13 +388,6 @@ def test_schema_and_round_trip() -> None:
     assert model2 == model
 
 
-pydantic_version = tuple(int(x) for x in pydantic.__version__.split(".")[:2])
-
-
-@pytest.mark.skipif(
-    pydantic_version < (2, 11),
-    reason="Schema generation requires pydantic >= 2.11",
-)
 def test_schema_file_updated(pytestconfig: pytest.Config) -> None:
     """Ensure that geff-schema.json at the repo root is up to date.
 


### PR DESCRIPTION
This PR updates the Affine model

closes #254 (in conjunction with #267)

The primary goal here is to:
1. provide better indication of what the matrix must be in the json schema (i.e. list of list of float), which is done via the `json_schema_input_schema` in the TFormMeta object.
2. get rid of `arbitrary_types_allowed` and store an actual numpy array by giving pydantic all the info it needs to cast any object to a well-formed square homogenous matrix (with `Annotated[np.ndarray, TFormMeta]`)

cc @ilan-theodoro please review :)

-----

I stopped there, however I think it's worth discussing (in another PR) whether there should be an `Affine` class *at all*.  One could simply make the GeffMetadata.affine field *directly* a `Annotated[np.ndarray, TFormMeta]`... in which case the schema would look like:

```json
"affine": {
  "anyOf": [
    {
      "items": {
        "items": {
          "type": "number"
        },
        "type": "array"
      },
      "type": "array"
    },
    {
      "type": "null"
    }
  ],
  "default": null,
  "description": "Affine transformation matrix to transform the graph coordinates to the physical coordinates. The matrix must have the same number of dimensions as the number of axes in the graph."
},
```

This does mean you take some of the convenience methods off the `Affine`... but I generally favor pure models that just say what they are, without trying to add too much of a "convenience API" on top of it (as tempting as it is! 😄 )... since it's just all the more to possibly break.  It doesn't stop you from having a functional module that adds some of these conveniences, but it does makes the model clean and direct.  The main reason to *keep* the full `Affine` object is if you intend to eventually have something *other* than one single `matrix` field on it