### PR TITLE
Validate units with cf-units package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ dependencies = [
     "numpy>=1.24",
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=2.1; python_version >= '3.13'",
-    "numcodecs>=0.13,<0.16",                           # TODO: remove pin once the 16 release is stable
-    "numcodecs>=0.15,<0.16; python_version >= '3.13'", # TODO: remove pin once the 16 release is stable
+    "numcodecs>=0.13,<0.16", # TODO: remove pin once the 16 release is stable
+    "numcodecs>=0.15,<0.16; python_version >= '3.13'",
+    "cf-units>=3.3.0",
 ]
 
 classifiers = [

--- a/src/geff/metadata_schema.py
+++ b/src/geff/metadata_schema.py
@@ -53,18 +53,24 @@ class Axis(BaseModel):
                 stacklevel=2,
             )
 
-        if self.type == "space" and not validate_space_unit(self.unit):  # type: ignore
-            warnings.warn(
-                f"Spatial unit {self.unit} not in valid OME-Zarr units {VALID_SPACE_UNITS}. "
-                "Reader applications may not know what to do with this information.",
-                stacklevel=2,
-            )
-        elif self.type == "time" and not validate_time_unit(self.unit):  # type: ignore
-            warnings.warn(
-                f"Temporal unit {self.unit} not in valid OME-Zarr units {VALID_TIME_UNITS}. "
-                "Reader applications may not know what to do with this information.",
-                stacklevel=2,
-            )
+        if self.type == "space":
+            if validate_space_unit(self.unit):  # type: ignore
+                (self.unit in VALID_SPACE_UNITS) or warnings.warn(
+                    f"Spatial unit {self.unit} not in valid OME-Zarr units {VALID_SPACE_UNITS}. "
+                    "Reader applications may not know what to do with this information.",
+                    stacklevel=2,
+                )
+            else:
+                raise ValueError(f"{self.unit} is not a valid space unit")
+        elif self.type == "time":
+            if validate_time_unit(self.unit):  # type: ignore
+                (self.unit in VALID_TIME_UNITS) or warnings.warn(
+                    f"Temporal unit {self.unit} not in valid OME-Zarr units {VALID_TIME_UNITS}. "
+                    "Reader applications may not know what to do with this information.",
+                    stacklevel=2,
+                )
+            else:
+                raise ValueError(f"{self.unit} is not a valid time unit")
 
         return self
 

--- a/src/geff/valid_values.py
+++ b/src/geff/valid_values.py
@@ -96,7 +96,13 @@ def validate_space_unit(unit_name: str) -> bool:
         bool: True if a space unit is a KNOWN valid unit.
         False if the unit is not known. The unit may be valid.
     """
-    return unit_name in VALID_SPACE_UNITS or cf_units.Unit(unit_name).convert(1, "micrometer")
+    try:
+        return unit_name in VALID_SPACE_UNITS or cf_units.Unit(unit_name).convert(1, "micrometer")
+    except ValueError as err:
+        # Conversion to micrometer should not error
+        if str(err).startswith("Unable to convert"):
+            return False
+        raise
 
 
 def validate_time_unit(unit_name: str) -> bool:

--- a/src/geff/valid_values.py
+++ b/src/geff/valid_values.py
@@ -1,6 +1,7 @@
 import encodings
 import pkgutil
 
+import cf_units
 import numpy as np
 
 # -----------------------------------------------------------------------------
@@ -95,7 +96,7 @@ def validate_space_unit(unit_name: str) -> bool:
         bool: True if a space unit is a KNOWN valid unit.
         False if the unit is not known. The unit may be valid.
     """
-    return unit_name in VALID_SPACE_UNITS
+    return unit_name in VALID_SPACE_UNITS or cf_units.Unit(unit_name).convert(1, "micrometer")
 
 
 def validate_time_unit(unit_name: str) -> bool:
@@ -108,7 +109,7 @@ def validate_time_unit(unit_name: str) -> bool:
         bool: True if a time unit is a KNOWN valid unit.
         False if the unit is not known. The unit may be valid.
     """
-    return unit_name in VALID_TIME_UNITS
+    return unit_name in VALID_TIME_UNITS or cf_units.Unit(unit_name).is_time()
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_agnostic/test_metadata_schema.py
+++ b/tests/test_agnostic/test_metadata_schema.py
@@ -328,12 +328,24 @@ class TestAxis:
 
     def test_invalid_units(self):
         # Spatial
-        with pytest.warns(UserWarning, match=r"Spatial unit .* not in valid"):
+        with pytest.raises(pydantic.ValidationError, match=r"Failed to parse unit \"bad unit\""):
             Axis(name="test", type="space", unit="bad unit")
 
+        with pytest.raises(pydantic.ValidationError, match=r"second is not a valid space unit."):
+            Axis(name="test", type="space", unit="second")
+
+        with pytest.warns(UserWarning, match=r"Spatial unit .* not in valid"):
+            Axis(name="test", type="space", unit="micrometers")
+
         # Temporal
-        with pytest.warns(UserWarning, match=r"Temporal unit .* not in valid"):
+        with pytest.raises(pydantic.ValidationError, match=r"Failed to parse unit \"bad unit\""):
             Axis(name="test", type="time", unit="bad unit")
+        
+        with pytest.raises(pydantic.ValidationError, match=r"micrometer is not a valid time unit."):
+            Axis(name="test", type="time", unit="micrometer")
+
+        with pytest.warns(UserWarning, match=r"Temporal unit .* not in valid"):
+            Axis(name="test", type="time", unit="seconds")
 
         # Don't check units if we don't specify type
         Axis(name="test", unit="not checked")


### PR DESCRIPTION
# Proposed Change
Expands the valid units to include anything that the `cf-units` python package (and thus the [UDUNITS-2 C library](https://www.unidata.ucar.edu/software/udunits/)) recognizes. This relaxes the definition with regard to OME-NGFF in that we allow forms outside of the enumerated strings in the OME-NGFF specification which units SHOULD be.

In particular, this allows for plural forms such as "micrometers" or "seconds".

# Types of Changes
- Bugfix (non-breaking change which fixes an issue)
  - JSON in specification.md is now valid
- New feature or enhancement
  - Expands units to include those recognized by cf-units

Which topics does your change affect? Delete those that do not apply.
- Specification

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).

## If you changed the specification
- [x] I have checked that any validation functions and tests reflect the changes.
- [x] I have updated the GeffMetadata and the json schema using `pytest --update-schema` if necessary.
- [x] I have updated docs/specification.md to reflect the change.
- [x] I have updated implementations to reflect the change. (This can happen in separate PRs on a feature branch, but must be complete before merging into main.)

# Further comments

We could remove the list of valid units completely if we use this definition.
