### PR TITLE
Fixing zarr 3 `write_arrays`

### DIFF
--- a/src/geff/write_arrays.py
+++ b/src/geff/write_arrays.py
@@ -54,7 +54,7 @@ def write_arrays(
     """
     geff_store = remove_tilde(geff_store)
 
-    write_id_arrays(geff_store, node_ids, edge_ids)
+    write_id_arrays(geff_store, node_ids, edge_ids, zarr_format=zarr_format)
     if node_props is not None:
         write_props_arrays(
             geff_store, "nodes", node_props, node_props_unsquish, zarr_format=zarr_format

--- a/tests/test_agnostic/test_write_arrays.py
+++ b/tests/test_agnostic/test_write_arrays.py
@@ -1,12 +1,17 @@
+from pathlib import Path
+from typing import Literal
+
 import numpy as np
 import zarr
+import pytest
 
 from geff.metadata_schema import GeffMetadata
 from geff.write_arrays import write_arrays
 
 
 class TestWriteArrays:
-    def test_write_arrays_basic(self, tmp_path):
+    @pytest.mark.parametrize("zarr_format", [2, 3])
+    def test_write_arrays_basic(self, tmp_path: Path, zarr_format: Literal[2, 3]) -> None:
         """Test basic functionality of write_arrays with minimal data."""
         # Create test data
         geff_path = tmp_path / "test.geff"
@@ -22,6 +27,7 @@ class TestWriteArrays:
             edge_ids=edge_ids,
             edge_props=None,
             metadata=metadata,
+            zarr_format=zarr_format,
         )
 
         # Verify the zarr group was created

--- a/tests/test_agnostic/test_write_arrays.py
+++ b/tests/test_agnostic/test_write_arrays.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
-import zarr
 import pytest
+import zarr
 
 from geff.metadata_schema import GeffMetadata
 from geff.write_arrays import write_arrays


### PR DESCRIPTION
# Proposed Change

The current version of `write_arrays` is broken for zarr 3.
The IDs were being written as zarr 2, and the zarr storage was removed and replaced by an empty zarr 3 storage when writing the props. 

# Types of Changes
- Bugfix (non-breaking change which fixes an issue)
- 
# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).