### PR TITLE
Add missing spaces in dtype description

### DIFF
--- a/geff-schema.json
+++ b/geff-schema.json
@@ -304,7 +304,7 @@
           "type": "string"
         },
         "dtype": {
-          "description": "Data type of the property. Must be a non-empty string that can beparsed into a numpy dtype, or the special value 'varlength' to indicatea variable length property. Examples of valid values: 'int', 'int16', 'float64', 'str', 'bool'. Examples of invalid values: 'integer', 'np.int16', 'number', 'string'.",
+          "description": "Data type of the property. Must be a non-empty string that can be parsed into a numpy dtype, or the special value 'varlength' to indicate a variable length property. Examples of valid values: 'int', 'int16', 'float64', 'str', 'bool'. Examples of invalid values: 'integer', 'np.int16', 'number', 'string'.",
           "minLength": 1,
           "title": "Dtype",
           "type": "string"

--- a/src/geff/metadata/_prop_metadata.py
+++ b/src/geff/metadata/_prop_metadata.py
@@ -25,8 +25,8 @@ class PropMetadata(BaseModel):
     dtype: Annotated[str, MinLen(1)] = Field(
         ...,
         description=(
-            "Data type of the property. Must be a non-empty string that can be"
-            "parsed into a numpy dtype, or the special value 'varlength' to indicate"
+            "Data type of the property. Must be a non-empty string that can be "
+            "parsed into a numpy dtype, or the special value 'varlength' to indicate "
             "a variable length property. "
             "Examples of valid values: 'int', 'int16', 'float64', 'str', 'bool'. "
             "Examples of invalid values: 'integer', 'np.int16', 'number', 'string'."


### PR DESCRIPTION
# Proposed Change
Just fixing typos from previous PR (#302 )

- [x] I have updated the GeffMetadata and the json schema using `pytest --update-schema` if necessary.