### PR TITLE
Document loading subsets of geff files

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -7,12 +7,7 @@ Using a lower level component ([`GeffReader`][geff.GeffReader]) of the `geff` AP
 ### Loading a subset of properties
 
 ```python
-from geff import GeffReader
-
-# Load the construct function for your choice of graph
-from geff._graph_libs._networkx import construct_nx
-# from geff._graph_libs._rustworkx import construct_rx
-# from geff._graph_libs._spatial_graph import construct_sg
+from geff import GeffReader, construct
 
 
 # Open the geff file without reading any data into memory
@@ -29,8 +24,8 @@ geff_reader.read_edge_props()
 # Read the data of the geff into memory including only properties that have been loaded
 in_memory_geff = geff_reader.build()
 
-# Construct a graph representation of the data
-graph = construct_nx(**in_memory_geff)
+# Construct a graph representation of the data with the backend of your choice
+graph = construct(**in_memory_geff, backend="networkx")
 # Nodes will contain the attributes t, x, and y
 # Edges will contain the attributes color and score
 ```
@@ -38,12 +33,7 @@ graph = construct_nx(**in_memory_geff)
 ### Filtering based on nodes
 
 ```python
-from geff import GeffReader
-
-# Load the construct function for your choice of graph
-from geff._graph_libs._networkx import construct_nx
-# from geff._graph_libs._rustworkx import construct_rx
-# from geff._graph_libs._spatial_graph import construct_sg
+from geff import GeffReader, construct
 
 
 # Open the geff file without reading any data into memory
@@ -57,8 +47,8 @@ node_mask = file_reader.node_props["t"]["values"][:] < 5
 # Read the data of the geff into memory using the mask to filter which nodes to load
 in_memory_geff = geff_reader.build(node_mask=node_mask)
 
-# Construct a graph representation of the data
-graph = construct_nx(**in_memory_geff)
+# Construct a graph representation of the data with the backend of your choice
+graph = construct(**in_memory_geff, backend="networkx")
 ```
 
 ### Filtering based on edges
@@ -68,12 +58,7 @@ graph = construct_nx(**in_memory_geff)
     When loading a GEFF using an edge mask, by default all nodes will be loaded even if they are not contained within an unmasked edge. However `GeffReader.build` can take both a node and edge mask if constructed by the user.
 
 ```python
-from geff import GeffReader
-
-# Load the construct function for your choice of graph
-from geff._graph_libs._networkx import construct_nx
-# from geff._graph_libs._rustworkx import construct_rx
-# from geff._graph_libs._spatial_graph import construct_sg
+from geff import GeffReader, construct
 
 
 # Open the geff file without reading any data into memory
@@ -87,6 +72,6 @@ edge_mask = file_reader.edge_props["score"]["values"][:] < 0.5
 # Read the data of the geff into memory using the mask to filter which edges to load
 in_memory_geff = geff_reader.build(edge_mask=edge_mask)
 
-# Construct a graph representation of the data
-graph = construct_nx(**in_memory_geff)
+# Construct a graph representation of the data with the backend of your choice
+graph = construct(**in_memory_geff, backend="networkx")
 ```

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -1,0 +1,92 @@
+# Tips and Tricks
+
+## Loading a subset of a GEFF
+
+Using a lower level component ([`GeffReader`][geff.GeffReader]) of the `geff` API, it is possible to load a subset of a graph based on a mask that is applied either to nodes or edges. 
+
+### Loading a subset of properties
+
+```python
+from geff import GeffReader
+
+# Load the construct function for your choice of graph
+from geff._graph_libs._networkx import construct_nx
+# from geff._graph_libs._rustworkx import construct_rx
+# from geff._graph_libs._spatial_graph import construct_sg
+
+
+# Open the geff file without reading any data into memory
+geff_reader = GeffReader(path)
+
+# Print names of available node/edge properties
+print(reader.node_prop_names, reader.edge_prop_names)
+# >>> (['t', 'x', 'y', 'label', 'score'] ['color', 'score'])
+
+geff_reader.read_node_props(['t', 'x', 'y'])
+# By default all edge properties will be loaded
+geff_reader.read_edge_props()
+
+# Read the data of the geff into memory including only properties that have been loaded
+in_memory_geff = geff_reader.build()
+
+# Construct a graph representation of the data
+graph = construct_nx(**in_memory_geff)
+# Nodes will contain the attributes t, x, and y
+# Edges will contain the attributes color and score
+```
+
+### Filtering based on nodes
+
+```python
+from geff import GeffReader
+
+# Load the construct function for your choice of graph
+from geff._graph_libs._networkx import construct_nx
+# from geff._graph_libs._rustworkx import construct_rx
+# from geff._graph_libs._spatial_graph import construct_sg
+
+
+# Open the geff file without reading any data into memory
+geff_reader = GeffReader(path)
+# Load edge and node properties
+geff_reader.read_node_props()
+geff_reader.read_edge_props()
+# Access the property values, load it into memory as a numpy and then create the mask
+node_mask = file_reader.node_props["t"]["values"][:] < 5
+
+# Read the data of the geff into memory using the mask to filter which nodes to load
+in_memory_geff = geff_reader.build(node_mask=node_mask)
+
+# Construct a graph representation of the data
+graph = construct_nx(**in_memory_geff)
+```
+
+### Filtering based on edges
+
+!!! note
+
+    When loading a GEFF using an edge mask, by default all nodes will be loaded even if they are not contained within an unmasked edge. However `GeffReader.build` can take both a node and edge mask if constructed by the user.
+
+```python
+from geff import GeffReader
+
+# Load the construct function for your choice of graph
+from geff._graph_libs._networkx import construct_nx
+# from geff._graph_libs._rustworkx import construct_rx
+# from geff._graph_libs._spatial_graph import construct_sg
+
+
+# Open the geff file without reading any data into memory
+geff_reader = GeffReader(path)
+# Load edge and node properties
+geff_reader.read_node_props()
+geff_reader.read_edge_props()
+# Access the property values, load it into memory as a numpy and then create the mask
+edge_mask = file_reader.edge_props["score"]["values"][:] < 0.5
+
+# Read the data of the geff into memory using the mask to filter which edges to load
+in_memory_geff = geff_reader.build(edge_mask=edge_mask)
+
+# Construct a graph representation of the data
+graph = construct_nx(**in_memory_geff)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - specification.md
   - tracking.md
   - command-line-tools.md
+  - tips-and-tricks.md
 
 theme:
   name: "material"


### PR DESCRIPTION
Closes #227 by providing examples of how to load either some properties of a geff or either a subset of nodes/edges. The imports for the construct functions are ugly at the moment and will change with #308. I think we should expose a universal construct function along with read and write that we expose at the top level geff import. But that can happen in another PR. 

~~Alternatively after #308 is merged I think we could update the code blocks to something like this~~ Code blocks are now updated and ready to merge in after #308 is merged.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Documentation update

Which topics does your change affect? Delete those that do not apply.

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.