### PR TITLE
Enforce node ids must be uint

### DIFF
--- a/src/geff/convert/_ctc.py
+++ b/src/geff/convert/_ctc.py
@@ -194,7 +194,7 @@ def from_ctc_to_geff(
     if "z" in node_props:
         axis_names.insert(1, Axis(name="z", type="space"))
 
-    node_ids = np.asarray(node_props.pop("id"), dtype=int)
+    node_ids = np.asarray(node_props.pop("id"), dtype="uint")
 
     write_arrays(
         geff_store=geff_path,

--- a/src/geff/core_io/_base_write.py
+++ b/src/geff/core_io/_base_write.py
@@ -60,8 +60,16 @@ def write_dicts(
 
     if len(node_ids) > 0:
         nodes_arr = np.asarray(node_ids)
+        # Check if we can cast to uint
+        if any(nodes_arr < 0):
+            raise ValueError("Cannot write a geff with node ids that are negative")
+        if not np.issubdtype(nodes_arr.dtype, np.integer):
+            warnings.warn(
+                f"Node ids with dtype {nodes_arr.dtype} are being cast to uint", stacklevel=2
+            )
+        nodes_arr = nodes_arr.astype("uint")
     else:
-        nodes_arr = np.empty((0,), dtype=np.int64)
+        nodes_arr = np.empty((0,), dtype=np.uint64)
 
     if len(edge_ids) > 0:
         edges_arr = np.asarray(edge_ids, dtype=nodes_arr.dtype)

--- a/src/geff/validate/structure.py
+++ b/src/geff/validate/structure.py
@@ -115,8 +115,8 @@ def _validate_nodes_group(nodes_group: zarr.Group, metadata: GeffMetadata) -> No
 
     # Node ids must be int dtype
     # TODO: enforce uint
-    if not np.issubdtype(np.dtype(node_ids.dtype), np.integer):
-        raise ValueError("Node ids must have an integer dtype")
+    if not np.issubdtype(np.dtype(node_ids.dtype), np.unsignedinteger):
+        raise ValueError("Node ids must have an unsigned integer dtype")
 
     id_len = node_ids.shape[0]
     node_props = expect_group(nodes_group, _path.PROPS, _path.NODES)
@@ -131,6 +131,8 @@ def _validate_edges_group(edges_group: zarr.Group, metadata: GeffMetadata) -> No
         raise ValueError(
             f"edges ids must have a last dimension of size 2, received shape {edges_ids.shape}"
         )
+    if not np.issubdtype(np.dtype(edges_ids.dtype), np.unsignedinteger):
+        raise ValueError("Edge ids must have an unsigned integer dtype")
 
     # Edge property array length should match edge id length
     edge_id_len = edges_ids.shape[0]

--- a/tests/test_core_io/test_base_read.py
+++ b/tests/test_core_io/test_base_read.py
@@ -7,7 +7,7 @@ from geff.core_io._base_read import read_to_memory
 from geff.testing.data import create_mock_geff, create_simple_2d_geff
 from geff.validate.data import ValidationConfig
 
-node_id_dtypes = ["int8", "uint8", "int16", "uint16"]
+node_id_dtypes = ["uint8", "uint16"]
 node_axis_dtypes = [
     {"position": "double", "time": "double"},
     {"position": "int", "time": "int"},

--- a/tests/test_core_io/test_base_write.py
+++ b/tests/test_core_io/test_base_write.py
@@ -7,6 +7,7 @@ import pytest
 import zarr
 import zarr.storage
 
+from geff import _path
 from geff.core_io import write_arrays
 from geff.core_io._base_read import read_to_memory
 from geff.metadata._schema import GeffMetadata
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from geff._typing import PropDictNpArray
 
 
-from geff.core_io._base_write import dict_props_to_arr
+from geff.core_io._base_write import dict_props_to_arr, write_dicts
 
 
 def _tmp_metadata():
@@ -41,8 +42,8 @@ class TestWriteArrays:
         """Test basic functionality of write_arrays with minimal data."""
         # Create test data
         geff_path = tmp_path / "test.geff"
-        node_ids = np.array([1, 2, 3], dtype=np.int32)
-        edge_ids = np.array([[1, 2], [2, 3]], dtype=np.int32)
+        node_ids = np.array([1, 2, 3], dtype=np.uint32)
+        edge_ids = np.array([[1, 2], [2, 3]], dtype=np.uint32)
         metadata = GeffMetadata(geff_version="0.0.1", directed=True)
 
         with warnings.catch_warnings():
@@ -55,9 +56,9 @@ class TestWriteArrays:
             write_arrays(
                 geff_store=geff_path,
                 node_ids=node_ids,
-                node_props=None,
+                node_props={},
                 edge_ids=edge_ids,
-                edge_props=None,
+                edge_props={},
                 metadata=metadata,
                 zarr_format=zarr_format,
             )
@@ -82,6 +83,8 @@ class TestWriteArrays:
         assert "geff" in root.attrs
         assert root.attrs["geff"]["geff_version"] == "0.0.1"
         assert root.attrs["geff"]["directed"] is True
+
+        validate_structure(geff_path)
 
     # TODO: test properties helper. It's covered by networkx tests now, so I'm okay merging,
     # but we should do it when we have time.
@@ -163,3 +166,29 @@ def test_dict_prop_to_arr(dict_data, data_type, expected) -> None:
 
 # TODO: test write_dicts (it is pretty solidly covered by networkx and write_array tests,
 # so I'm okay merging without, but we should do it when we have time)
+
+
+class Test_write_dicts:
+    def test_node_ids_not_int(self):
+        store = zarr.storage.MemoryStore()
+        node_data = [(float(node), {}) for node in range(10)]
+
+        with pytest.raises(UserWarning, match=r"Node ids with dtype .* are being cast to uint"):
+            write_dicts(store, node_data, [], [], [])
+
+            z = zarr.open(store)
+            assert np.issubdtype(z[_path.NODE_IDS].dtype, np.unsignedinteger)
+
+    def test_node_int_to_uint(self):
+        store = zarr.storage.MemoryStore()
+        node_data = [(node, {}) for node in range(10)]
+        write_dicts(store, node_data, [], [], [])
+
+        z = zarr.open(store)
+        assert np.issubdtype(z[_path.NODE_IDS].dtype, np.unsignedinteger)
+
+    def test_negative_ids(self):
+        store = zarr.storage.MemoryStore()
+        node_data = [(-node, {}) for node in range(10)]
+        with pytest.raises(ValueError, match="Cannot write a geff with node ids that are negative"):
+            write_dicts(store, node_data, [], [], [])

--- a/tests/test_graph_libs/test_api_wrapper.py
+++ b/tests/test_graph_libs/test_api_wrapper.py
@@ -12,7 +12,7 @@ from geff.testing.data import create_mock_geff
 rx = pytest.importorskip("rustworkx")
 sg = pytest.importorskip("spatial_graph")
 
-node_id_dtypes = ["int8", "uint8", "int16", "uint16"]
+node_id_dtypes = ["uint8", "uint16"]
 node_axis_dtypes = [
     {"position": "double", "time": "double"},
     {"position": "int", "time": "int"},

--- a/tests/test_graph_libs/test_nx_basics.py
+++ b/tests/test_graph_libs/test_nx_basics.py
@@ -7,7 +7,7 @@ import geff
 from geff.metadata._schema import GeffMetadata, _axes_from_lists
 from geff.testing.data import create_mock_geff
 
-node_id_dtypes = ["int8", "uint8", "int16", "uint16"]
+node_id_dtypes = ["uint8", "uint16"]
 node_axis_dtypes = [
     {"position": "double", "time": "double"},
     {"position": "int", "time": "int"},

--- a/tests/test_graph_libs/test_nx_basics.py
+++ b/tests/test_graph_libs/test_nx_basics.py
@@ -26,7 +26,7 @@ extra_edge_props = [
 @pytest.mark.parametrize("directed", [True, False])
 @pytest.mark.parametrize("include_t", [True, False])
 @pytest.mark.parametrize("include_z", [True, False])
-def test_read_write_consistency(
+def test_read_consistency(
     tmp_path,
     node_id_dtype,
     node_axis_dtypes,

--- a/tests/test_graph_libs/test_rx_basics.py
+++ b/tests/test_graph_libs/test_rx_basics.py
@@ -8,7 +8,7 @@ from geff.testing.data import create_mock_geff
 
 rx = pytest.importorskip("rustworkx")
 
-node_id_dtypes = ["int8", "uint8", "int16", "uint16"]
+node_id_dtypes = ["uint8", "uint16"]
 node_axis_dtypes = [
     {"position": "double", "time": "double"},
     {"position": "int", "time": "int"},

--- a/tests/test_graph_libs/test_sg_basics.py
+++ b/tests/test_graph_libs/test_sg_basics.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from geff.testing.data import create_mock_geff
 
-node_dtypes = ["int8", "uint8", "int16", "uint16"]
+node_dtypes = ["uint8", "uint16"]
 node_attr_dtypes = [
     {"position": "double", "time": "double"},
     {"position": "int", "time": "int"},

--- a/tests/test_testing/test_testing_data.py
+++ b/tests/test_testing/test_testing_data.py
@@ -174,7 +174,7 @@ class Test_create_mock_geff:
         }
 
         store, memory_geff = create_mock_geff(
-            node_id_dtype="int",
+            node_id_dtype="uint",
             node_axis_dtypes={"position": "float64", "time": "float64"},
             directed=False,
             num_nodes=5,
@@ -249,7 +249,7 @@ class Test_create_mock_geff:
         """Test create_mock_geff with no extra node properties"""
 
         store, _ = create_mock_geff(
-            node_id_dtype="int",
+            node_id_dtype="uint",
             node_axis_dtypes={"position": "float64", "time": "float64"},
             extra_edge_props={"score": "float64", "color": "int"},
             directed=False,
@@ -426,7 +426,7 @@ class Test_create_mock_geff:
         }
 
         store, _ = create_mock_geff(
-            node_id_dtype="int",
+            node_id_dtype="uint",
             node_axis_dtypes={"position": "float64", "time": "float64"},
             extra_edge_props={"score": "float64", "color": "int", "type": "str"},
             directed=False,

--- a/tests/test_validate/test_structure.py
+++ b/tests/test_validate/test_structure.py
@@ -102,13 +102,13 @@ class Test_validate_nodes_group:
 
     def test_ids_not_int(self, node_group, meta):
         node_group[_path.IDS] = node_group[_path.IDS][:].astype("float")
-        with pytest.raises(ValueError, match="Node ids must have an integer dtype"):
+        with pytest.raises(ValueError, match="Node ids must have an unsigned integer dtype"):
             _validate_nodes_group(node_group, meta)
 
-        # TODO: Must be positive integers
-        # node_group[_path.IDS] = node_group[_path.IDS][:] * -1
-        # with pytest.raises(ValueError, match="Node ids must have an integer dtype"):
-        #     _validate_nodes_group(node_group, meta)
+        # Must be uint, not just int
+        node_group[_path.IDS] = node_group[_path.IDS][:].astype("int")
+        with pytest.raises(ValueError, match="Node ids must have an unsigned integer dtype"):
+            _validate_nodes_group(node_group, meta)
 
     # Other cases are caught in tests for _validate_props_group
 
@@ -126,6 +126,14 @@ class Test_validate_edges_group:
         with pytest.raises(
             ValueError,
             match="edges ids must have a last dimension of size 2, received shape .*",
+        ):
+            _validate_edges_group(edge_group, meta)
+
+    def test_edge_ids_not_uint(self, edge_group, meta):
+        edge_group[_path.IDS] = edge_group[_path.IDS][:].astype("float")
+        with pytest.raises(
+            ValueError,
+            match="Edge ids must have an unsigned integer dtype",
         ):
             _validate_edges_group(edge_group, meta)
 


### PR DESCRIPTION
Closes #176 

The main issue was that when `write_dicts` constructs an array of node_ids the step of `np.asarray` doesn't guarantee a uint output even if we started with uint node ids.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)
- Tests

Which topics does your change affect? Delete those that do not apply.
- Specification
- Core io

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).