### PR TITLE
Improve schema/metadata documentation

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,22 +8,15 @@ The graph exchange file format is `zarr` based. A graph is stored in a zarr grou
 
 Currently, `geff` supports zarr specifications [2](https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html) and [3](https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html). However, `geff` will default to writing specification 2 because graphs written to the zarr v3 spec will not be compatible with all applications. When zarr 3 is more fully adopted by other libraries and tools, we will move to a zarr spec 3 default.
 
-## Geff metadata
-This is an auto-generated description of the schema for GEFF metadata. Further description of specific sections of interest are below.
-
-<!-- GEFF-SCHEMA -->
-
-### Axes list
-
-The axes list is modeled after the [OME-zarr](https://ngff.openmicroscopy.org/0.5/index.html#axes-md) specifications and is used to identify spatio-temporal properties on the graph nodes. If the same names are used in the axes metadata of the related image or segmentation data, applications can use this information to align graph node locations with image data. 
-
-The order of the axes in the list is meaningful. For one, any downstream properties that are an array of values with one value per (spatial) axis will be in the order of the axis list (filtering to only the spatial axes by the `type` field if needed). Secondly, if associated image or segmentation data does not have axes metadata, the order of the spatiotemporal axes is a good default guess for aligning the graph and the image data, although there is no way to denote the channel dimension in the graph spec. If you are writing out a geff with an associated segmentation and/or image dataset, we highly recommend providing the axis names for your segmentation/image using the OME-zarr spec, including channel dimensions if needed.
-
-::: geff.metadata._valid_values.VALID_AXIS_TYPES
-
-::: geff.metadata._valid_values.VALID_SPACE_UNITS
-
-::: geff.metadata._valid_values.VALID_TIME_UNITS
+::: geff.GeffMetadata
+    options:
+        heading_level: 2
+        filters:
+            - "!read"
+            - "!write"
+        docstring_section_style: table
+        show_symbol_type_heading: false
+        show_symbol_type_toc: false
 
 ### Property metadata
 The metadata for each node/edge property is (optionally) stored in the `node_props_metadata` and `edge_props_metadata` entries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,8 +31,8 @@ extra:
     provider: mike
     default: latest
 
-hooks:
-  - docs/_hooks.py
+# hooks:
+  # - docs/_hooks.py
 
 markdown_extensions:
   - admonition
@@ -51,7 +51,7 @@ plugins:
         options:
           docstring_section_style: table # or "table"
           docstring_style: "google"
-    #       filters: ["!^_"]
+          filters: ["!_^"]
           heading_level: 3 
           merge_init_into_class: true
           # parameter_headings: true # makes parameters show up in side TOC
@@ -63,6 +63,12 @@ plugins:
           show_symbol_type_toc: true
           # summary: true
           line_length: 60
+          show_docstring_attributes: true
+          show_attribute_values: true
+          show_labels: false
+          extensions:
+          - griffe_pydantic:
+                schema: false
 - include-markdown
 - api-autonav:
     modules: ['src/geff']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ docs = [
     "mkdocs-typer>=0.0.3",
     "ruff>=0.12.5",
     "typing-extensions>=4.14.1",
-    "mkdocs-autorefs"
+    "mkdocs-autorefs",
+    "griffe-pydantic"
 ]
 bench = [
     { include-group = "test" },

--- a/src/geff/metadata/_schema.py
+++ b/src/geff/metadata/_schema.py
@@ -32,7 +32,36 @@ VERSION_PATTERN = r"^\d+\.\d+(?:\.\d+)?(?:\.dev\d+)?(?:\+[a-zA-Z0-9]+)?"
 
 
 class Axis(BaseModel):
-    """TODO docstring"""
+    """The axes list is modeled after the
+    [OME-zarr](https://ngff.openmicroscopy.org/0.5/index.html#axes-md)
+    specifications and is used to identify spatio-temporal properties on the
+    graph nodes. If the same names are used in the axes metadata of the
+    related image or segmentation data, applications can use this information
+    to align graph node locations with image data.
+
+    The order of the axes in the list is meaningful. For one, any downstream
+    properties that are an array of values with one value per (spatial) axis
+    will be in the order of the axis list (filtering to only the spatial axes by
+    the `type` field if needed). Secondly, if associated image or segmentation
+    data does not have axes metadata, the order of the spatiotemporal axes is a
+    good default guess for aligning the graph and the image data, although there
+    is no way to denote the channel dimension in the graph spec. If you are
+    writing out a geff with an associated segmentation and/or image dataset, we
+    highly recommend providing the axis names for your segmentation/image using
+    the OME-zarr spec, including channel dimensions if needed.
+
+    ::: geff.metadata._valid_values.AxisType
+        options:
+            heading_level: 3
+
+    ::: geff.metadata._valid_values.SpaceUnits
+        options:
+            heading_level: 3
+
+    ::: geff.metadata._valid_values.TimeUnits
+        options:
+            heading_level: 3
+    """
 
     name: str
     type: str | None = None
@@ -80,7 +109,7 @@ def _axes_from_lists(
     roi_min: Sequence[float | None] | None = None,
     roi_max: Sequence[float | None] | None = None,
 ) -> list[Axis]:
-    """Create a list of Axes objects from lists of axis names, units, types, mins,
+    """Create a list of objects from lists of axis names, units, types, mins,
     and maxes. If axis_names is None, there are no spatial axes and the list will
     be empty. Nones for all other arguments will omit them from the axes.
 
@@ -248,11 +277,12 @@ class GeffMetadata(BaseModel):
     directed: bool = Field(description="True if the graph is directed, otherwise False.")
     axes: list[Axis] | None = Field(
         default=None,
-        description="Optional list of Axis objects defining the axes of each node in the graph.\n"
+        description="Optional list of `Axis` objects defining the axes of each node in the graph.\n"
         "Each object's `name` must be an existing attribute on the nodes. The optional `type` key"
         "must be one of `space`, `time` or `channel`, though readers may not use this information. "
         "Each axis can additionally optionally define a `unit` key, which should match the valid"
-        "OME-Zarr units, and `min` and `max` keys to define the range of the axis.",
+        "OME-Zarr units, and `min` and `max` keys to define the range of the axis. See "
+        "[`Axis`][geff.metadata._schema.Axis] for more information.",
     )
 
     node_props_metadata: dict[str, PropMetadata] | None = Field(


### PR DESCRIPTION
# Proposed Change
This PR is a WIP to improve how we document geff schema/metadata in the specification. I removed the embedded html version of the schema and am replacing it with direct documentation of the pydantic models. Some massaging and refinement is needed, but I'd like to get feedback before I go any further. 

One open question is where certain types of information should live. For example, for the axes metadata, there is a class docstring, the field description in GeffMetadata and a block of text in the specification docs. Currently I moved the block of text from the specification into the Axis class docstring, but I'm not sure if that's the best pattern. 

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Documentation update

Which topics does your change affect? Delete those that do not apply.
- Specification

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).