### PR TITLE
Switch to running benchmarking on codspeed macro to collect walltime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
 
   benchmark:
     name: Run Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
I'm testing if recording walltime during codspeed benchmarking will be more informative and potentially stabilize our benchmark times. I'm still not entirely clear on what causes all of the variability in the spatial-graph benchmarks and so further investigation may be needed.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Delete those that do not apply.


# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).
