### PR TITLE
Allow node ids to be signed or unsigned int

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -24,7 +24,7 @@ The nodes group will contain an `ids` array and optionally a `props` group.
 
 ### The `ids` array
 
-The `nodes\ids` array is a 1D array of node IDs of length `N` >= 0, where `N` is the number of nodes in the graph. Node ids must be unique. Node IDs must have an unsigned integer dtype. For large graphs, `uint64` might be necessary to provide enough range for every node to have a unique ID. In the minimal case of an empty graph, the `ids` array will be present but empty.
+The `nodes\ids` array is a 1D array of node IDs of length `N` >= 0, where `N` is the number of nodes in the graph. Node ids must be unique. Node IDs must have an integer dtype. For large graphs, `int64` might be necessary to provide enough range for every node to have a unique ID. In the minimal case of an empty graph, the `ids` array will be present but empty.
 
 ### The `props` group and `node property` groups
 

--- a/src/geff/validate/structure.py
+++ b/src/geff/validate/structure.py
@@ -138,8 +138,8 @@ def _validate_nodes_group(nodes_group: zarr.Group, metadata: GeffMetadata) -> No
     node_ids = expect_array(nodes_group, _path.IDS, _path.NODES)
 
     # Node ids must be uint dtype
-    if not np.issubdtype(np.dtype(node_ids.dtype), np.unsignedinteger):
-        raise ValueError("Node ids must have an unsigned integer dtype")
+    if not np.issubdtype(np.dtype(node_ids.dtype), np.integer):
+        raise ValueError("Node ids must have an integer dtype")
 
     id_len = node_ids.shape[0]
     node_props = expect_group(nodes_group, _path.PROPS, _path.NODES)

--- a/tests/test_validate/test_structure.py
+++ b/tests/test_validate/test_structure.py
@@ -103,12 +103,7 @@ class Test_validate_nodes_group:
 
     def test_ids_not_int(self, node_group, meta):
         node_group[_path.IDS] = node_group[_path.IDS][:].astype("float")
-        with pytest.raises(ValueError, match="Node ids must have an unsigned integer dtype"):
-            _validate_nodes_group(node_group, meta)
-
-        # Must be uint, not just int
-        node_group[_path.IDS] = node_group[_path.IDS][:].astype("int")
-        with pytest.raises(ValueError, match="Node ids must have an unsigned integer dtype"):
+        with pytest.raises(ValueError, match="Node ids must have an integer dtype"):
             _validate_nodes_group(node_group, meta)
 
     # Other cases are caught in tests for _validate_props_group


### PR DESCRIPTION
Based on a request from @lxenard, we are going to relax back to allowing signed or unsigned int as node ids.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- New feature or enhancement

Which topics does your change affect? Delete those that do not apply.
- Specification
- Validate

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).

## If you changed the specification
- [x] I have checked that any validation functions and tests reflect the changes.
- [x] I have updated the GeffMetadata and the json schema using `pytest --update-schema` if necessary.
- [x] I have updated docs/specification.md to reflect the change.
- [x] I have updated implementations to reflect the change. (This can happen in separate PRs on a feature branch, but must be complete before merging into main.)