### PR TITLE
Add gh release action to CI and use output of release notes generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,8 +140,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Generate geff changelog
         uses: mikepenz/release-changelog-builder-action@v5
+        id: build_changelog
         with:
-          includeOnlyPaths: |
+          includeOnlyPaths: | # Should work after v6 release
             docs/
             packages/geff
           configuration: changelog-config.json
@@ -156,6 +157,10 @@ jobs:
             }
           toTag: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: ${{steps.build_changelog.outputs.changelog}}
+          files: "./dist/*"
 
   upload-geff-spec-to-pypi:
     if: success() && startsWith(github.ref, 'refs/tags/spec') && github.event_name != 'schedule'
@@ -176,8 +181,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Generate geff-spec changelog
         uses: mikepenz/release-changelog-builder-action@v5
+        id: build_changelog_spec
         with:
-          includeOnlyPaths: |
+          includeOnlyPaths: | # Should work after v6 release
             packages/geff-spec
           configuration: changelog-config.json
           configurationJson: | # Filter only geff-spec tags
@@ -191,3 +197,7 @@ jobs:
             }
           toTag: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: ${{steps.build_changelog_spec.outputs.changelog}}
+          files: "./dist/*"


### PR DESCRIPTION
# Proposed Change
Hopefully get's our release process fully automated by adding the missing gh release step.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Maintenance (e.g. dependencies, CI, releases, etc.)