### PR TITLE
Always use geff-spec version in metadata (not geff)

### DIFF
--- a/packages/geff-spec/src/geff_spec/utils.py
+++ b/packages/geff-spec/src/geff_spec/utils.py
@@ -8,13 +8,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar
 import numpy as np
 from pydantic import validate_call
 
-import geff
-
 from ._axis import Axis
 
 # The next import is needed at runtime for Pydantic validation
 from ._prop_metadata import PropMetadata
-from ._schema import GeffMetadata
+from ._schema import GEFF_VERSION, GeffMetadata
 
 if TYPE_CHECKING:
     from ._valid_values import AxisType
@@ -124,13 +122,13 @@ def create_or_update_metadata(
     """
     if metadata is not None:
         metadata = copy.deepcopy(metadata)
-        metadata.geff_version = geff.__version__
+        metadata.geff_version = GEFF_VERSION
         metadata.directed = is_directed
         if axes is not None:
             metadata.axes = axes
     else:
         metadata = GeffMetadata(
-            geff_version=geff.__version__,
+            geff_version=GEFF_VERSION,
             directed=is_directed,
             axes=axes,
             node_props_metadata={},


### PR DESCRIPTION
# Proposed Change
I noticed after using the ctc converter that we were still ending up with the geff version in the metadata instead of the geff-spec version. This PR fixes that bug in one of our metadata utility functions.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)

Which topics does your change affect? Delete those that do not apply.
- Metadata

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).