### PR TITLE
Dataframe/csv to geff

### DIFF
--- a/docs/convert.md
+++ b/docs/convert.md
@@ -21,6 +21,14 @@ To convert a Trackmat XML file to GEFF using the `geff` cli, see the docs for [`
 
 To use the `geff` python API, see the docs for [`from_trackmate_xml_to_geff`][geff.convert.from_trackmate_xml_to_geff].
 
+## DataFrames / CSV
+
+To convert pandas DataFrames to a GEFF store, use [`dataframes_to_geff`][geff.convert.dataframes_to_geff]. The node DataFrame must have an ID column (default `"id"`) and the edge DataFrame must have source and target columns (default `"source"` and `"target"`). All other columns become node or edge properties.
+
+To convert CSV files directly, use [`csv_to_geff`][geff.convert.csv_to_geff]. The CSVs are expected to have a header row and a pandas-style index column.
+
+To convert in the other direction, use [`geff_to_dataframes`][geff.convert.geff_to_dataframes] or [`geff_to_csv`][geff.convert.geff_to_csv].
+
 ## AceTree
 
-An example of how to convert AceTree data to a GEFF is available [here](https://github.com/zhirongbaolab/AceTreePythonReader/blob/main/testAceTreeReaderGeffWrite.py). 
+An example of how to convert AceTree data to a GEFF is available [here](https://github.com/zhirongbaolab/AceTreePythonReader/blob/main/testAceTreeReaderGeffWrite.py).

--- a/packages/geff/pyproject.toml
+++ b/packages/geff/pyproject.toml
@@ -46,7 +46,7 @@ ctc = [
     "tifffile>=2024.10",
 ]
 rx = ["rustworkx>=0.16.0"]
-pandas = ["pandas>=2.1","pandas>=2.3; python_version >= '3.12'"]
+pandas = ["pandas>=2.2","pandas>=2.3; python_version >= '3.12'"]
 
 [project.urls]
 repository = "https://github.com/live-image-tracking-tools/geff"

--- a/packages/geff/pyproject.toml
+++ b/packages/geff/pyproject.toml
@@ -46,7 +46,7 @@ ctc = [
     "tifffile>=2024.10",
 ]
 rx = ["rustworkx>=0.16.0"]
-pandas = ["pandas>=2.2","pandas>=2.3; python_version >= '3.12'"]
+pandas = ["pandas>=2","pandas>=2.3; python_version >= '3.12'"]
 
 [project.urls]
 repository = "https://github.com/live-image-tracking-tools/geff"

--- a/packages/geff/pyproject.toml
+++ b/packages/geff/pyproject.toml
@@ -46,7 +46,7 @@ ctc = [
     "tifffile>=2024.10",
 ]
 rx = ["rustworkx>=0.16.0"]
-pandas = ["pandas>=2","pandas>=2.3; python_version >= '3.12'"]
+pandas = ["pandas>=2.1","pandas>=2.3; python_version >= '3.12'"]
 
 [project.urls]
 repository = "https://github.com/live-image-tracking-tools/geff"

--- a/packages/geff/src/geff/convert/__init__.py
+++ b/packages/geff/src/geff/convert/__init__.py
@@ -5,18 +5,18 @@ from geff.convert._trackmate_xml import from_trackmate_xml_to_geff
 if TYPE_CHECKING:
     from ._ctc import ctc_tiffs_to_zarr, from_ctc_to_geff
     from ._dataframe import (
+        _dataframes_to_memory_geff,
         csv_to_geff,
         dataframes_to_geff,
-        dataframes_to_memory_geff,
         geff_to_csv,
         geff_to_dataframes,
     )
 
 __all__ = [
+    "_dataframes_to_memory_geff",
     "csv_to_geff",
     "ctc_tiffs_to_zarr",
     "dataframes_to_geff",
-    "dataframes_to_memory_geff",
     "from_ctc_to_geff",
     "from_trackmate_xml_to_geff",
     "geff_to_csv",
@@ -46,9 +46,9 @@ def __getattr__(name: str) -> Any:
 
         return dataframes_to_geff
     if name == "dataframes_to_memory_geff":
-        from geff.convert._dataframe import dataframes_to_memory_geff
+        from geff.convert._dataframe import _dataframes_to_memory_geff
 
-        return dataframes_to_memory_geff
+        return _dataframes_to_memory_geff
     if name == "geff_to_dataframes":
         from geff.convert._dataframe import geff_to_dataframes
 

--- a/packages/geff/src/geff/convert/__init__.py
+++ b/packages/geff/src/geff/convert/__init__.py
@@ -4,6 +4,13 @@ from geff.convert._trackmate_xml import from_trackmate_xml_to_geff
 
 if TYPE_CHECKING:
     from ._ctc import ctc_tiffs_to_zarr, from_ctc_to_geff
+    from ._dataframe import (
+        csv_to_geff,
+        dataframes_to_geff,
+        dataframes_to_memory_geff,
+        geff_to_csv,
+        geff_to_dataframes,
+    )
 
 __all__ = [
     "csv_to_geff",

--- a/packages/geff/src/geff/convert/__init__.py
+++ b/packages/geff/src/geff/convert/__init__.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from ._ctc import ctc_tiffs_to_zarr, from_ctc_to_geff
 
 __all__ = [
+    "csv_to_geff",
     "ctc_tiffs_to_zarr",
     "dataframes_to_geff",
     "dataframes_to_memory_geff",
@@ -25,6 +26,10 @@ def __getattr__(name: str) -> Any:
         from geff.convert._ctc import from_ctc_to_geff
 
         return from_ctc_to_geff
+    if name == "csv_to_geff":
+        from geff.convert._dataframe import csv_to_geff
+
+        return csv_to_geff
     if name == "geff_to_csv":
         from geff.convert._dataframe import geff_to_csv
 

--- a/packages/geff/src/geff/convert/__init__.py
+++ b/packages/geff/src/geff/convert/__init__.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ctc_tiffs_to_zarr",
+    "dataframes_to_geff",
+    "dataframes_to_memory_geff",
     "from_ctc_to_geff",
     "from_trackmate_xml_to_geff",
     "geff_to_csv",
@@ -27,6 +29,14 @@ def __getattr__(name: str) -> Any:
         from geff.convert._dataframe import geff_to_csv
 
         return geff_to_csv
+    if name == "dataframes_to_geff":
+        from geff.convert._dataframe import dataframes_to_geff
+
+        return dataframes_to_geff
+    if name == "dataframes_to_memory_geff":
+        from geff.convert._dataframe import dataframes_to_memory_geff
+
+        return dataframes_to_memory_geff
     if name == "geff_to_dataframes":
         from geff.convert._dataframe import geff_to_dataframes
 

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -27,7 +27,7 @@ def geff_to_dataframes(
     """
     Convert a GEFF store to a pandas DataFrame.
 
-    Properties with more than 2 dimensions cannot be converted and will be skipped
+    Properties with more than 2 dimensions cannot be converted and will be skipped.
     Properties with two dimensions where the second dimension is > 1 will be unpacked
     into separate columns with the name "{prop_name}_{dim_index}"
 
@@ -92,9 +92,10 @@ def geff_to_dataframes(
 def geff_to_csv(store: StoreLike, outpath: Path | str, overwrite: bool = False) -> None:
     """Convert a geff store to two csvs of nodes and edges
 
-    Properties with more than 2 dimensions cannot be exported and will be skipped
+    Properties with more than 2 dimensions cannot be exported and will be skipped.
     Properties with two dimensions where the second dimension is > 1 will be unpacked
-    into separate columns with the name "{prop_name}_{dim_index}"
+    into separate columns with the name "{prop_name}_{dim_index}", and saved in extra
+    metadata.
 
     Args:
         store (StoreLike): Path to store or StoreLike object
@@ -139,9 +140,27 @@ def dataframes_to_memory_geff(
         edge_source_col: Name of the source node column in edge_df. Defaults to "source".
         edge_target_col: Name of the target node column in edge_df. Defaults to "target".
 
+    Raises:
+        ValueError: If node_df is missing the node_id_col column, or edge_df is
+            missing the edge_source_col or edge_target_col columns.
+
     Returns:
         InMemoryGeff: A dict with metadata, node_ids, edge_ids, node_props, and edge_props.
     """
+    # Validate required columns
+    if node_id_col not in node_df.columns:
+        raise ValueError(
+            f"node_df must contain a {node_id_col!r} column. Found columns: {list(node_df.columns)}"
+        )
+    missing_edge_cols = [
+        col for col in (edge_source_col, edge_target_col) if col not in edge_df.columns
+    ]
+    if missing_edge_cols:
+        raise ValueError(
+            f"edge_df must contain {missing_edge_cols} column(s). "
+            f"Found columns: {list(edge_df.columns)}"
+        )
+
     # Extract node IDs
     if len(node_df) > 0:
         node_ids = np.asarray(node_df[node_id_col]).astype(np.uint64)
@@ -250,17 +269,30 @@ def csv_to_geff(
 ) -> None:
     """Convert CSV files to a geff store.
 
-    Reads node and edge CSV files and writes them to a geff store.
+    Reads node and edge CSV files into pandas DataFrames and writes them to a
+    geff store. The CSVs are expected to have a header row and a pandas-style
+    index column (column 0).
+
+    The node CSV must contain a column with node IDs (default "id"). All other
+    columns are stored as node properties. The edge CSV must contain columns for
+    source and target node IDs (default "source" and "target"). All other columns
+    are stored as edge properties. Missing values (empty cells / NaN) are recorded
+    in the GEFF missing mask.
 
     Args:
         node_csv: Path to the node CSV file.
         edge_csv: Path to the edge CSV file.
         store: The zarr store to write to.
         directed: Whether the graph is directed. Defaults to True.
-        node_id_col: Name of the node ID column. Defaults to "id".
-        edge_source_col: Name of the source node column. Defaults to "source".
-        edge_target_col: Name of the target node column. Defaults to "target".
+        node_id_col: Name of the node ID column in the node CSV. Defaults to "id".
+        edge_source_col: Name of the source node column in the edge CSV.
+            Defaults to "source".
+        edge_target_col: Name of the target node column in the edge CSV.
+            Defaults to "target".
         zarr_format: The zarr specification to use when writing. Defaults to 2.
+
+    Raises:
+        ValueError: If required columns are missing from the CSVs.
     """
     node_df = pd.read_csv(node_csv, index_col=0)
     edge_df = pd.read_csv(edge_csv, index_col=0)

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -5,10 +5,20 @@ except ImportError as e:
 
 import warnings
 from pathlib import Path
+from typing import Literal
 
+import numpy as np
 from zarr.storage import StoreLike
 
+from geff._typing import InMemoryGeff, PropDictNpArray
 from geff.core_io._base_read import read_to_memory
+from geff.core_io._base_write import write_arrays
+from geff.core_io._utils import construct_props
+from geff_spec.utils import (
+    add_or_update_props_metadata,
+    create_or_update_metadata,
+    create_props_metadata,
+)
 
 
 def geff_to_dataframes(
@@ -103,3 +113,126 @@ def geff_to_csv(store: StoreLike, outpath: Path | str, overwrite: bool = False) 
     mode = "w" if overwrite else "x"
     node_df.to_csv(node_path, mode=mode)
     edge_df.to_csv(edge_path, mode=mode)
+
+
+def dataframes_to_memory_geff(
+    node_df: pd.DataFrame,
+    edge_df: pd.DataFrame,
+    directed: bool = True,
+    node_id_col: str = "id",
+    edge_source_col: str = "source",
+    edge_target_col: str = "target",
+) -> InMemoryGeff:
+    """Convert pandas DataFrames to an InMemoryGeff representation.
+
+    This is the inverse of geff_to_dataframes. Takes a node DataFrame and an edge
+    DataFrame and converts them into the InMemoryGeff dict format. Missing values
+    (NaN/None) are handled via boolean missing masks with correct dtypes preserved.
+
+    Args:
+        node_df: DataFrame with node data. Must contain a node ID column and any
+            number of property columns.
+        edge_df: DataFrame with edge data. Must contain source and target ID columns
+            and any number of property columns.
+        directed: Whether the graph is directed. Defaults to True.
+        node_id_col: Name of the node ID column in node_df. Defaults to "id".
+        edge_source_col: Name of the source node column in edge_df. Defaults to "source".
+        edge_target_col: Name of the target node column in edge_df. Defaults to "target".
+
+    Returns:
+        InMemoryGeff: A dict with metadata, node_ids, edge_ids, node_props, and edge_props.
+    """
+    # Extract node IDs
+    if len(node_df) > 0:
+        node_ids = np.asarray(node_df[node_id_col]).astype(np.uint64)
+    else:
+        node_ids = np.empty((0,), dtype=np.uint64)
+
+    # Extract edge IDs
+    if len(edge_df) > 0:
+        edge_ids = np.column_stack(
+            [
+                np.asarray(edge_df[edge_source_col]),
+                np.asarray(edge_df[edge_target_col]),
+            ]
+        ).astype(np.uint64)
+    else:
+        edge_ids = np.empty((0, 2), dtype=np.uint64)
+
+    # Convert property columns to PropDictNpArray
+    node_prop_cols = [c for c in node_df.columns if c != node_id_col]
+    node_props = _df_columns_to_props(node_df, node_prop_cols)
+
+    edge_prop_cols = [c for c in edge_df.columns if c not in (edge_source_col, edge_target_col)]
+    edge_props = _df_columns_to_props(edge_df, edge_prop_cols)
+
+    # Build metadata
+    metadata = create_or_update_metadata(metadata=None, is_directed=directed)
+    node_prop_meta = [
+        create_props_metadata(identifier=name, prop_data=prop_data)
+        for name, prop_data in node_props.items()
+    ]
+    edge_prop_meta = [
+        create_props_metadata(identifier=name, prop_data=prop_data)
+        for name, prop_data in edge_props.items()
+    ]
+    metadata = add_or_update_props_metadata(metadata, node_prop_meta, "node")
+    metadata = add_or_update_props_metadata(metadata, edge_prop_meta, "edge")
+
+    return {
+        "metadata": metadata,
+        "node_ids": node_ids,
+        "edge_ids": edge_ids,
+        "node_props": node_props,
+        "edge_props": edge_props,
+    }
+
+
+def _df_columns_to_props(df: pd.DataFrame, columns: list[str]) -> dict[str, PropDictNpArray]:
+    """Convert DataFrame columns to a dict of PropDictNpArray.
+
+    Replaces NaN/None with None before passing to construct_props, which handles
+    default value filling and missing mask creation.
+    """
+    props: dict[str, PropDictNpArray] = {}
+    for col in columns:
+        values = [None if pd.isna(v) else v for v in df[col]]
+        props[col] = construct_props(values)
+    return props
+
+
+def dataframes_to_geff(
+    node_df: pd.DataFrame,
+    edge_df: pd.DataFrame,
+    store: StoreLike,
+    directed: bool = True,
+    node_id_col: str = "id",
+    edge_source_col: str = "source",
+    edge_target_col: str = "target",
+    zarr_format: Literal[2, 3] = 2,
+) -> None:
+    """Convert pandas DataFrames and write directly to a geff store.
+
+    Combines dataframes_to_geff with write_arrays for convenience.
+
+    Args:
+        node_df: DataFrame with node data. Must contain a node ID column and any
+            number of property columns.
+        edge_df: DataFrame with edge data. Must contain source and target ID columns
+            and any number of property columns.
+        store: The zarr store to write to.
+        directed: Whether the graph is directed. Defaults to True.
+        node_id_col: Name of the node ID column in node_df. Defaults to "id".
+        edge_source_col: Name of the source node column in edge_df. Defaults to "source".
+        edge_target_col: Name of the target node column in edge_df. Defaults to "target".
+        zarr_format: The zarr specification to use when writing. Defaults to 2.
+    """
+    in_memory_geff = dataframes_to_memory_geff(
+        node_df,
+        edge_df,
+        directed=directed,
+        node_id_col=node_id_col,
+        edge_source_col=edge_source_col,
+        edge_target_col=edge_target_col,
+    )
+    write_arrays(store, zarr_format=zarr_format, **in_memory_geff)

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -115,7 +115,7 @@ def geff_to_csv(store: StoreLike, outpath: Path | str, overwrite: bool = False) 
     edge_df.to_csv(edge_path, mode=mode)
 
 
-def dataframes_to_memory_geff(
+def _dataframes_to_memory_geff(
     node_df: pd.DataFrame,
     edge_df: pd.DataFrame,
     directed: bool = True,
@@ -286,7 +286,7 @@ def dataframes_to_geff(
         edge_target_col (str): Name of the target node column in edge_df. Defaults to "target".
         zarr_format (Literal[2, 3]): The zarr specification to use when writing. Defaults to 2.
     """
-    in_memory_geff = dataframes_to_memory_geff(
+    in_memory_geff = _dataframes_to_memory_geff(
         node_df,
         edge_df,
         directed=directed,

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -236,3 +236,42 @@ def dataframes_to_geff(
         edge_target_col=edge_target_col,
     )
     write_arrays(store, zarr_format=zarr_format, **in_memory_geff)
+
+
+def csv_to_geff(
+    node_csv: Path | str,
+    edge_csv: Path | str,
+    store: StoreLike,
+    directed: bool = True,
+    node_id_col: str = "id",
+    edge_source_col: str = "source",
+    edge_target_col: str = "target",
+    zarr_format: Literal[2, 3] = 2,
+) -> None:
+    """Convert CSV files to a geff store.
+
+    Reads node and edge CSV files and writes them to a geff store.
+
+    Args:
+        node_csv: Path to the node CSV file.
+        edge_csv: Path to the edge CSV file.
+        store: The zarr store to write to.
+        directed: Whether the graph is directed. Defaults to True.
+        node_id_col: Name of the node ID column. Defaults to "id".
+        edge_source_col: Name of the source node column. Defaults to "source".
+        edge_target_col: Name of the target node column. Defaults to "target".
+        zarr_format: The zarr specification to use when writing. Defaults to 2.
+    """
+    node_df = pd.read_csv(node_csv, index_col=0)
+    edge_df = pd.read_csv(edge_csv, index_col=0)
+
+    dataframes_to_geff(
+        node_df,
+        edge_df,
+        store,
+        directed=directed,
+        node_id_col=node_id_col,
+        edge_source_col=edge_source_col,
+        edge_target_col=edge_target_col,
+        zarr_format=zarr_format,
+    )

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -13,7 +13,7 @@ from zarr.storage import StoreLike
 from geff._typing import InMemoryGeff, PropDictNpArray
 from geff.core_io._base_read import read_to_memory
 from geff.core_io._base_write import write_arrays
-from geff.core_io._utils import construct_props
+from geff.core_io._utils import _infer_int_dtype, construct_props
 from geff_spec.utils import (
     add_or_update_props_metadata,
     create_or_update_metadata,
@@ -165,9 +165,9 @@ def _dataframes_to_memory_geff(
         raw_node_ids = np.asarray(node_df[node_id_col])
         id_dtype = _infer_int_dtype(raw_node_ids)
         node_ids = raw_node_ids.astype(id_dtype)
-    # Default to uint8 if no nodes 
+    # Default to uint8 if no nodes
     else:
-        id_dtype = np.uint8
+        id_dtype = np.dtype(np.uint8)
         node_ids = np.empty((0,), dtype=id_dtype)
 
     # Extract edge IDs
@@ -208,33 +208,6 @@ def _dataframes_to_memory_geff(
         "node_props": node_props,
         "edge_props": edge_props,
     }
-
-
-def _infer_int_dtype(values: np.ndarray) -> np.dtype:
-    """Infer the smallest integer dtype that can represent all values.
-
-    Uses an unsigned type when all values are non-negative, otherwise signed.
-
-    Args:
-        values (np.ndarray): 1-D array of integer values.
-
-    Returns:
-        np.dtype: The smallest numpy integer dtype that fits the data.
-    """
-    min_val = values.min()
-    max_val = values.max()
-
-    if min_val < 0:
-        for signed in (np.int8, np.int16, np.int32, np.int64):
-            info = np.iinfo(signed)
-            if info.min <= min_val and max_val <= info.max:
-                return np.dtype(signed)
-    else:
-        for unsigned in (np.uint8, np.uint16, np.uint32, np.uint64):
-            if max_val <= np.iinfo(unsigned).max:
-                return np.dtype(unsigned)
-
-    raise ValueError(f"ID values (min={min_val}, max={max_val}) exceed supported integer range")
 
 
 def _df_columns_to_props(df: pd.DataFrame, columns: list[str]) -> dict[str, PropDictNpArray]:

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -270,14 +270,14 @@ def csv_to_geff(
     """Convert CSV files to a geff store.
 
     Reads node and edge CSV files into pandas DataFrames and writes them to a
-    geff store. The CSVs are expected to have a header row and a pandas-style
-    index column (column 0).
+    geff store. The CSVs are expected to have a header row.
 
     The node CSV must contain a column with node IDs (default "id"). All other
     columns are stored as node properties. The edge CSV must contain columns for
     source and target node IDs (default "source" and "target"). All other columns
     are stored as edge properties. Missing values (empty cells / NaN) are recorded
-    in the GEFF missing mask.
+    in the GEFF missing mask. Columns starting with "Unnamed:" are ignored (e.g.
+    pandas index columns written by ``df.to_csv()``).
 
     Args:
         node_csv: Path to the node CSV file.
@@ -294,8 +294,12 @@ def csv_to_geff(
     Raises:
         ValueError: If required columns are missing from the CSVs.
     """
-    node_df = pd.read_csv(node_csv, index_col=0)
-    edge_df = pd.read_csv(edge_csv, index_col=0)
+    node_df = pd.read_csv(node_csv)
+    edge_df = pd.read_csv(edge_csv)
+
+    # Drop unnamed columns (e.g. pandas index columns written by df.to_csv())
+    node_df = node_df.loc[:, ~node_df.columns.str.startswith("Unnamed:")]
+    edge_df = edge_df.loc[:, ~edge_df.columns.str.startswith("Unnamed:")]
 
     dataframes_to_geff(
         node_df,

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -94,8 +94,7 @@ def geff_to_csv(store: StoreLike, outpath: Path | str, overwrite: bool = False) 
 
     Properties with more than 2 dimensions cannot be exported and will be skipped.
     Properties with two dimensions where the second dimension is > 1 will be unpacked
-    into separate columns with the name "{prop_name}_{dim_index}", and saved in extra
-    metadata.
+    into separate columns with the name "{prop_name}_{dim_index}"
 
     Args:
         store (StoreLike): Path to store or StoreLike object
@@ -126,19 +125,19 @@ def dataframes_to_memory_geff(
 ) -> InMemoryGeff:
     """Convert pandas DataFrames to an InMemoryGeff representation.
 
-    This is the inverse of geff_to_dataframes. Takes a node DataFrame and an edge
-    DataFrame and converts them into the InMemoryGeff dict format. Missing values
-    (NaN/None) are handled via boolean missing masks with correct dtypes preserved.
+    Takes a node DataFrame and an edge DataFrame and converts them into the InMemoryGeff
+    dict format. Missing values (NaN/None) are handled via boolean missing masks with
+    correct dtypes preserved.
 
     Args:
-        node_df: DataFrame with node data. Must contain a node ID column and any
-            number of property columns.
-        edge_df: DataFrame with edge data. Must contain source and target ID columns
+        node_df (pd.DataFrame): DataFrame with node data. Must contain a node ID column
             and any number of property columns.
-        directed: Whether the graph is directed. Defaults to True.
-        node_id_col: Name of the node ID column in node_df. Defaults to "id".
-        edge_source_col: Name of the source node column in edge_df. Defaults to "source".
-        edge_target_col: Name of the target node column in edge_df. Defaults to "target".
+        edge_df (pd.DataFrame): DataFrame with edge data. Must contain source and target
+            ID columns and any number of property columns.
+        directed (bool): Whether the graph is directed. Defaults to True.
+        node_id_col (str): Name of the node ID column in node_df. Defaults to "id".
+        edge_source_col (str): Name of the source node column in edge_df. Defaults to "source".
+        edge_target_col (str): Name of the target node column in edge_df. Defaults to "target".
 
     Raises:
         ValueError: If node_df is missing the node_id_col column, or edge_df is
@@ -212,6 +211,13 @@ def _df_columns_to_props(df: pd.DataFrame, columns: list[str]) -> dict[str, Prop
 
     Replaces NaN/None with None before passing to construct_props, which handles
     default value filling and missing mask creation.
+
+    Args:
+        df (pd.DataFrame): DataFrame containing the columns to convert.
+        columns (list[str]): List of column names to convert.
+
+    Returns:
+        dict[str, PropDictNpArray]: A mapping of column names to PropDictNpArray dicts.
     """
     props: dict[str, PropDictNpArray] = {}
     for col in columns:
@@ -230,21 +236,26 @@ def dataframes_to_geff(
     edge_target_col: str = "target",
     zarr_format: Literal[2, 3] = 2,
 ) -> None:
-    """Convert pandas DataFrames and write directly to a geff store.
+    """Convert node and edge pandas DataFrames to a geff store.
 
-    Combines dataframes_to_geff with write_arrays for convenience.
+    The node DataFrame must contain a column with node IDs (default "id"). All other
+    columns are stored as node properties. The edge DataFrame must contain columns for
+    source and target node IDs (default "source" and "target"). All other columns
+    are stored as edge properties. Missing values (NaN) are recorded
+    in the GEFF missing mask. Columns starting with "Unnamed:" are ignored (e.g.
+    pandas index columns written by ``df.to_csv()``).
 
     Args:
-        node_df: DataFrame with node data. Must contain a node ID column and any
-            number of property columns.
-        edge_df: DataFrame with edge data. Must contain source and target ID columns
+        node_df (pd.DataFrame): DataFrame with node data. Must contain a node ID column
             and any number of property columns.
-        store: The zarr store to write to.
-        directed: Whether the graph is directed. Defaults to True.
-        node_id_col: Name of the node ID column in node_df. Defaults to "id".
-        edge_source_col: Name of the source node column in edge_df. Defaults to "source".
-        edge_target_col: Name of the target node column in edge_df. Defaults to "target".
-        zarr_format: The zarr specification to use when writing. Defaults to 2.
+        edge_df (pd.DataFrame): DataFrame with edge data. Must contain source and target
+            ID columns and any number of property columns.
+        store (StoreLike): The zarr store to write to.
+        directed (bool): Whether the graph is directed. Defaults to True.
+        node_id_col (str): Name of the node ID column in node_df. Defaults to "id".
+        edge_source_col (str): Name of the source node column in edge_df. Defaults to "source".
+        edge_target_col (str): Name of the target node column in edge_df. Defaults to "target".
+        zarr_format (Literal[2, 3]): The zarr specification to use when writing. Defaults to 2.
     """
     in_memory_geff = dataframes_to_memory_geff(
         node_df,
@@ -267,11 +278,9 @@ def csv_to_geff(
     edge_target_col: str = "target",
     zarr_format: Literal[2, 3] = 2,
 ) -> None:
-    """Convert CSV files to a geff store.
+    """Convert node and edge CSV files to a geff store.
 
-    Reads node and edge CSV files into pandas DataFrames and writes them to a
-    geff store. The CSVs are expected to have a header row.
-
+    The CSVs are expected to have a header row.
     The node CSV must contain a column with node IDs (default "id"). All other
     columns are stored as node properties. The edge CSV must contain columns for
     source and target node IDs (default "source" and "target"). All other columns
@@ -280,16 +289,16 @@ def csv_to_geff(
     pandas index columns written by ``df.to_csv()``).
 
     Args:
-        node_csv: Path to the node CSV file.
-        edge_csv: Path to the edge CSV file.
-        store: The zarr store to write to.
-        directed: Whether the graph is directed. Defaults to True.
-        node_id_col: Name of the node ID column in the node CSV. Defaults to "id".
-        edge_source_col: Name of the source node column in the edge CSV.
+        node_csv (Path | str): Path to the node CSV file.
+        edge_csv (Path | str): Path to the edge CSV file.
+        store (StoreLike): The zarr store to write to.
+        directed (bool): Whether the graph is directed. Defaults to True.
+        node_id_col (str): Name of the node ID column in the node CSV. Defaults to "id".
+        edge_source_col (str): Name of the source node column in the edge CSV.
             Defaults to "source".
-        edge_target_col: Name of the target node column in the edge CSV.
+        edge_target_col (str): Name of the target node column in the edge CSV.
             Defaults to "target".
-        zarr_format: The zarr specification to use when writing. Defaults to 2.
+        zarr_format (Literal[2, 3]): The zarr specification to use when writing. Defaults to 2.
 
     Raises:
         ValueError: If required columns are missing from the CSVs.

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -161,12 +161,13 @@ def _dataframes_to_memory_geff(
         )
 
     # Infer the smallest integer dtype from node IDs (edge IDs are a subset)
-    raw_node_ids = np.asarray(node_df[node_id_col]) if len(node_df) > 0 else np.empty((0,))
-    id_dtype = _infer_int_dtype(raw_node_ids) if len(raw_node_ids) > 0 else np.dtype(np.uint8)
-
-    # Extract node IDs
-    node_ids = raw_node_ids.astype(id_dtype)
-    if len(node_ids) == 0:
+    if len(node_df) > 0:
+        raw_node_ids = np.asarray(node_df[node_id_col])
+        id_dtype = _infer_int_dtype(raw_node_ids)
+        node_ids = raw_node_ids.astype(id_dtype)
+    # Default to uint8 if no nodes 
+    else:
+        id_dtype = np.uint8
         node_ids = np.empty((0,), dtype=id_dtype)
 
     # Extract edge IDs

--- a/packages/geff/src/geff/convert/_dataframe.py
+++ b/packages/geff/src/geff/convert/_dataframe.py
@@ -160,11 +160,14 @@ def dataframes_to_memory_geff(
             f"Found columns: {list(edge_df.columns)}"
         )
 
+    # Infer the smallest integer dtype from node IDs (edge IDs are a subset)
+    raw_node_ids = np.asarray(node_df[node_id_col]) if len(node_df) > 0 else np.empty((0,))
+    id_dtype = _infer_int_dtype(raw_node_ids) if len(raw_node_ids) > 0 else np.dtype(np.uint8)
+
     # Extract node IDs
-    if len(node_df) > 0:
-        node_ids = np.asarray(node_df[node_id_col]).astype(np.uint64)
-    else:
-        node_ids = np.empty((0,), dtype=np.uint64)
+    node_ids = raw_node_ids.astype(id_dtype)
+    if len(node_ids) == 0:
+        node_ids = np.empty((0,), dtype=id_dtype)
 
     # Extract edge IDs
     if len(edge_df) > 0:
@@ -173,9 +176,9 @@ def dataframes_to_memory_geff(
                 np.asarray(edge_df[edge_source_col]),
                 np.asarray(edge_df[edge_target_col]),
             ]
-        ).astype(np.uint64)
+        ).astype(id_dtype)
     else:
-        edge_ids = np.empty((0, 2), dtype=np.uint64)
+        edge_ids = np.empty((0, 2), dtype=id_dtype)
 
     # Convert property columns to PropDictNpArray
     node_prop_cols = [c for c in node_df.columns if c != node_id_col]
@@ -204,6 +207,33 @@ def dataframes_to_memory_geff(
         "node_props": node_props,
         "edge_props": edge_props,
     }
+
+
+def _infer_int_dtype(values: np.ndarray) -> np.dtype:
+    """Infer the smallest integer dtype that can represent all values.
+
+    Uses an unsigned type when all values are non-negative, otherwise signed.
+
+    Args:
+        values (np.ndarray): 1-D array of integer values.
+
+    Returns:
+        np.dtype: The smallest numpy integer dtype that fits the data.
+    """
+    min_val = values.min()
+    max_val = values.max()
+
+    if min_val < 0:
+        for signed in (np.int8, np.int16, np.int32, np.int64):
+            info = np.iinfo(signed)
+            if info.min <= min_val and max_val <= info.max:
+                return np.dtype(signed)
+    else:
+        for unsigned in (np.uint8, np.uint16, np.uint32, np.uint64):
+            if max_val <= np.iinfo(unsigned).max:
+                return np.dtype(unsigned)
+
+    raise ValueError(f"ID values (min={min_val}, max={max_val}) exceed supported integer range")
 
 
 def _df_columns_to_props(df: pd.DataFrame, columns: list[str]) -> dict[str, PropDictNpArray]:
@@ -241,9 +271,8 @@ def dataframes_to_geff(
     The node DataFrame must contain a column with node IDs (default "id"). All other
     columns are stored as node properties. The edge DataFrame must contain columns for
     source and target node IDs (default "source" and "target"). All other columns
-    are stored as edge properties. Missing values (NaN) are recorded
-    in the GEFF missing mask. Columns starting with "Unnamed:" are ignored (e.g.
-    pandas index columns written by ``df.to_csv()``).
+    are stored as edge properties. NaN values are considered missing and are recorded
+    in the GEFF missing mask.
 
     Args:
         node_df (pd.DataFrame): DataFrame with node data. Must contain a node ID column

--- a/packages/geff/src/geff/core_io/__init__.py
+++ b/packages/geff/src/geff/core_io/__init__.py
@@ -1,9 +1,10 @@
 from ._base_read import read_to_memory
 from ._base_write import write_arrays, write_dicts
-from ._utils import check_for_geff, construct_var_len_props, delete_geff
+from ._utils import check_for_geff, construct_props, construct_var_len_props, delete_geff
 
 __all__ = [
     "check_for_geff",
+    "construct_props",
     "construct_var_len_props",
     "delete_geff",
     "read_to_memory",

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -111,6 +111,7 @@ def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_na
     """Determine default value to fill in missing values
 
     Find the first non-missing value and then uses the following heuristics:
+    - Native python bool -> False
     - Native python numerical types (int, float) -> 0
     - Native python string -> ""
     - Otherwise, return the  value, which is definitely the right type and

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -8,6 +8,7 @@ import numpy as np
 from geff import _path
 from geff._typing import PropDictNpArray
 from geff.core_io._utils import (
+    _default_for_value,
     check_for_geff,
     construct_var_len_props,
     delete_geff,
@@ -110,13 +111,8 @@ def write_dicts(
 def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_name: str) -> Any:
     """Determine default value to fill in missing values
 
-    Find the first non-missing value and then uses the following heuristics:
-    - Native python bool -> False
-    - Native python numerical types (int, float) -> 0
-    - Native python string -> ""
-    - Otherwise, return the  value, which is definitely the right type and
-    shape, but is potentially both confusing and inefficient. Should reconsider in
-    the future.
+    Find the first non-missing value and return a type-appropriate default
+    using _default_for_value.
 
     If there are no non-missing values, warns and then returns 0.
 
@@ -132,15 +128,7 @@ def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_na
     for _, data_dict in data:
         # find first non-missing value
         if prop_name in data_dict:
-            value = data_dict[prop_name]
-            if isinstance(value, bool):
-                return False
-            elif isinstance(value, int | float):
-                return 0
-            elif isinstance(value, str):
-                return ""
-            else:
-                return value
+            return _default_for_value(data_dict[prop_name])
     warnings.warn(
         f"Property {prop_name} is not present on any graph elements. Using 0 as the default.",
         stacklevel=2,

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -8,9 +8,9 @@ import numpy as np
 from geff import _path
 from geff._typing import PropDictNpArray
 from geff.core_io._utils import (
-    _default_for_value,
     check_for_geff,
     construct_var_len_props,
+    default_for_value,
     delete_geff,
     remove_tilde,
     setup_zarr_group,
@@ -111,8 +111,12 @@ def write_dicts(
 def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_name: str) -> Any:
     """Determine default value to fill in missing values
 
-    Find the first non-missing value and return a type-appropriate default
-    using _default_for_value.
+    Uses the following heuristics:
+    - np.generic (np.bool_, np.int64, np.float32, etc.) -> type(value)(0)
+    - bool, int, float -> type(value)(0) (e.g. False, 0, 0.0)
+    - str -> ""
+    - Otherwise, returns the value itself, which preserves type and shape but
+      may be confusing or inefficient for some types.
 
     If there are no non-missing values, warns and then returns 0.
 
@@ -128,7 +132,7 @@ def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_na
     for _, data_dict in data:
         # find first non-missing value
         if prop_name in data_dict:
-            return _default_for_value(data_dict[prop_name])
+            return default_for_value(data_dict[prop_name])
     warnings.warn(
         f"Property {prop_name} is not present on any graph elements. Using 0 as the default.",
         stacklevel=2,

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -132,7 +132,9 @@ def _determine_default_value(data: Sequence[tuple[Any, dict[str, Any]]], prop_na
         # find first non-missing value
         if prop_name in data_dict:
             value = data_dict[prop_name]
-            if isinstance(value, int | float):
+            if isinstance(value, bool):
+                return False
+            elif isinstance(value, int | float):
                 return 0
             elif isinstance(value, str):
                 return ""

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import numpy as np
 import zarr
@@ -230,6 +230,83 @@ def _get_common_type_dims(arr_seq: Sequence[ArrayLike | None]) -> tuple[np.dtype
         dtype = np.dtype("int64")
         ndim = 1
     return dtype, ndim
+
+
+def _default_for_value(value: Any) -> Any:
+    """Return a type-appropriate default value for filling missing entries.
+
+    Uses the following heuristics:
+    - bool -> False
+    - int or float -> 0
+    - str -> ""
+    - Otherwise, returns the value itself, which preserves type and shape but
+      may be confusing or inefficient for some types.
+
+    Args:
+        value: A non-None example value to determine the default from.
+
+    Returns:
+        A default value with the same type (and shape, for the fallback case).
+    """
+    if isinstance(value, bool):
+        return False
+    elif isinstance(value, int | float):
+        return 0
+    elif isinstance(value, str):
+        return ""
+    else:
+        return value
+
+
+def construct_props(values: Sequence[Any | None]) -> PropDictNpArray:
+    """Convert a sequence of values with possible None entries into a PropDictNpArray.
+
+    Builds a values array and a missing mask from the input sequence. None entries
+    are replaced with a type-appropriate default value (False for bool, 0 for int/float,
+    "" for str) determined from the first non-None entry. The missing mask indicates
+    which positions were None.
+
+    Non-None values are expected to have a consistent type and shape so they can
+    form a regular numpy array. For variable-length or variable-shape values, use
+    construct_var_len_props instead.
+
+    Args:
+        values: A sequence of values with one entry per node or edge.
+            Missing values are indicated by None entries.
+
+    Returns:
+        PropDictNpArray: A dict with "values" as a numpy array of the appropriate dtype
+            and "missing" as a boolean numpy array (or None if no values were missing).
+    """
+    filled_values = []
+    missing = np.zeros(len(values), dtype=np.bool_)
+    default_val = None
+    missing_any = False
+
+    for i, value in enumerate(values):
+        if value is None:
+            if default_val is None:
+                # find first non-None value to determine default
+                for v in values:
+                    if v is not None:
+                        default_val = _default_for_value(v)
+                        break
+                else:
+                    warnings.warn(
+                        "All values are None. Using 0 as the default.",
+                        stacklevel=2,
+                    )
+                    default_val = 0
+            filled_values.append(default_val)
+            missing[i] = True
+            missing_any = True
+        else:
+            filled_values.append(value)
+
+    return {
+        "values": np.asarray(filled_values),
+        "missing": missing if missing_any else None,
+    }
 
 
 def construct_var_len_props(arr_seq: Sequence[ArrayLike | None]) -> PropDictNpArray:

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -241,8 +241,8 @@ def _default_for_value(value: Any) -> Any:
     upcasting when the values are later combined into a numpy array.
 
     Uses the following heuristics:
-    - bool or np.bool_ -> False (preserving dtype)
-    - int, float, np.integer, or np.floating -> 0 (preserving dtype)
+    - np.generic (np.bool_, np.int64, np.float32, etc.) -> type(value)(0)
+    - bool, int, float -> type(value)(0) (e.g. False, 0, 0.0)
     - str -> ""
     - Otherwise, returns the value itself, which preserves type and shape but
       may be confusing or inefficient for some types.
@@ -255,10 +255,8 @@ def _default_for_value(value: Any) -> Any:
     """
     if isinstance(value, np.generic):
         return type(value)(0)
-    elif isinstance(value, bool):
-        return False
-    elif isinstance(value, int | float):
-        return 0
+    elif isinstance(value, bool | int | float):
+        return type(value)(0)
     elif isinstance(value, str):
         return ""
     else:

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -232,7 +232,7 @@ def _get_common_type_dims(arr_seq: Sequence[ArrayLike | None]) -> tuple[np.dtype
     return dtype, ndim
 
 
-def _default_for_value(value: Any) -> Any:
+def default_for_value(value: Any) -> Any:
     """Return a type-appropriate default value for filling missing entries.
 
     Handles both native Python types and numpy scalar types (e.g. np.bool_,
@@ -294,7 +294,7 @@ def construct_props(values: Sequence[Any | None]) -> PropDictNpArray:
                 # find first non-None value to determine default
                 for v in values:
                     if v is not None:
-                        default_val = _default_for_value(v)
+                        default_val = default_for_value(v)
                         break
                 else:
                     warnings.warn(

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -235,9 +235,14 @@ def _get_common_type_dims(arr_seq: Sequence[ArrayLike | None]) -> tuple[np.dtype
 def _default_for_value(value: Any) -> Any:
     """Return a type-appropriate default value for filling missing entries.
 
+    Handles both native Python types and numpy scalar types (e.g. np.bool_,
+    np.int64, np.float32) which commonly arise when iterating pandas DataFrames.
+    For numpy scalars, returns a zero of the same dtype to avoid unnecessary
+    upcasting when the values are later combined into a numpy array.
+
     Uses the following heuristics:
-    - bool -> False
-    - int or float -> 0
+    - bool or np.bool_ -> False (preserving dtype)
+    - int, float, np.integer, or np.floating -> 0 (preserving dtype)
     - str -> ""
     - Otherwise, returns the value itself, which preserves type and shape but
       may be confusing or inefficient for some types.
@@ -248,7 +253,9 @@ def _default_for_value(value: Any) -> Any:
     Returns:
         A default value with the same type (and shape, for the fallback case).
     """
-    if isinstance(value, bool):
+    if isinstance(value, np.generic):
+        return type(value)(0)
+    elif isinstance(value, bool):
         return False
     elif isinstance(value, int | float):
         return 0

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -261,6 +261,33 @@ def default_for_value(value: Any) -> Any:
         return value
 
 
+def _infer_int_dtype(values: np.ndarray) -> np.dtype:
+    """Infer the smallest integer dtype that can represent all values.
+
+    Uses an unsigned type when all values are non-negative, otherwise signed.
+
+    Args:
+        values (np.ndarray): 1-D array of integer values.
+
+    Returns:
+        np.dtype: The smallest numpy integer dtype that fits the data.
+    """
+    min_val = values.min()
+    max_val = values.max()
+
+    if min_val < 0:
+        for signed in (np.int8, np.int16, np.int32, np.int64):
+            info = np.iinfo(signed)
+            if info.min <= min_val and max_val <= info.max:
+                return np.dtype(signed)
+    else:
+        for unsigned in (np.uint8, np.uint16, np.uint32, np.uint64):
+            if max_val <= np.iinfo(unsigned).max:
+                return np.dtype(unsigned)
+
+    raise ValueError(f"ID values (min={min_val}, max={max_val}) exceed supported integer range")
+
+
 def construct_props(values: Sequence[Any | None]) -> PropDictNpArray:
     """Convert a sequence of values with possible None entries into a PropDictNpArray.
 
@@ -268,6 +295,8 @@ def construct_props(values: Sequence[Any | None]) -> PropDictNpArray:
     are replaced with a type-appropriate default value (False for bool, 0 for int/float,
     "" for str) determined from the first non-None entry. The missing mask indicates
     which positions were None.
+
+    For integer dtypes, the smallest bit width is chosen that can represent the values.
 
     Non-None values are expected to have a consistent type and shape so they can
     form a regular numpy array. For variable-length or variable-shape values, use
@@ -306,8 +335,12 @@ def construct_props(values: Sequence[Any | None]) -> PropDictNpArray:
         else:
             filled_values.append(value)
 
+    values_arr = np.asarray(filled_values)
+    if np.issubdtype(values_arr.dtype, np.integer):
+        values_arr = values_arr.astype(_infer_int_dtype(values_arr))
+
     return {
-        "values": np.asarray(filled_values),
+        "values": values_arr,
         "missing": missing if missing_any else None,
     }
 

--- a/packages/geff/src/geff/core_io/_utils.py
+++ b/packages/geff/src/geff/core_io/_utils.py
@@ -253,9 +253,7 @@ def default_for_value(value: Any) -> Any:
     Returns:
         A default value with the same type (and shape, for the fallback case).
     """
-    if isinstance(value, np.generic):
-        return type(value)(0)
-    elif isinstance(value, bool | int | float):
+    if isinstance(value, np.generic | bool | int | float):
         return type(value)(0)
     elif isinstance(value, str):
         return ""

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -5,9 +5,8 @@ try:
     import pandas as pd
 
     from geff.convert._dataframe import (
-        _infer_int_dtype,
+        _dataframes_to_memory_geff,
         csv_to_geff,
-        dataframes_to_memory_geff,
         geff_to_csv,
         geff_to_dataframes,
     )
@@ -22,40 +21,6 @@ import pytest
 from geff import _path
 from geff.core_io._base_read import read_to_memory
 from geff.testing.data import create_mock_geff, create_simple_2d_geff, create_simple_3d_geff
-
-
-class Test_infer_int_dtype:
-    def test_small_unsigned(self):
-        values = np.array([0, 1, 255])
-        assert _infer_int_dtype(values) == np.dtype(np.uint8)
-
-    def test_uint16(self):
-        values = np.array([0, 256])
-        assert _infer_int_dtype(values) == np.dtype(np.uint16)
-
-    def test_uint32(self):
-        values = np.array([0, 2**16])
-        assert _infer_int_dtype(values) == np.dtype(np.uint32)
-
-    def test_uint64(self):
-        values = np.array([0, 2**32])
-        assert _infer_int_dtype(values) == np.dtype(np.uint64)
-
-    def test_negative_int8(self):
-        values = np.array([-1, 0, 127])
-        assert _infer_int_dtype(values) == np.dtype(np.int8)
-
-    def test_negative_int16(self):
-        values = np.array([-129, 0])
-        assert _infer_int_dtype(values) == np.dtype(np.int16)
-
-    def test_negative_int32(self):
-        values = np.array([-(2**15) - 1, 0])
-        assert _infer_int_dtype(values) == np.dtype(np.int32)
-
-    def test_negative_int64(self):
-        values = np.array([-(2**31) - 1, 0])
-        assert _infer_int_dtype(values) == np.dtype(np.int64)
 
 
 class Test_geff_to_dataframes:
@@ -302,7 +267,7 @@ class Test_dataframes_to_geff:
         edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
 
         with pytest.raises(ValueError, match="node_df must contain a 'id' column"):
-            dataframes_to_memory_geff(node_df, edge_df)
+            _dataframes_to_memory_geff(node_df, edge_df)
 
     def test_missing_edge_columns(self):
         """Should raise ValueError when edge_df is missing source/target columns."""
@@ -310,14 +275,14 @@ class Test_dataframes_to_geff:
         edge_df = pd.DataFrame({"src": [0], "tgt": [1]})
 
         with pytest.raises(ValueError, match="edge_df must contain"):
-            dataframes_to_memory_geff(node_df, edge_df)
+            _dataframes_to_memory_geff(node_df, edge_df)
 
     def test_empty_dataframes(self):
         """Empty DataFrames should produce valid InMemoryGeff with empty arrays."""
         node_df = pd.DataFrame({"id": pd.Series(dtype=int)})
         edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
 
-        result = dataframes_to_memory_geff(node_df, edge_df)
+        result = _dataframes_to_memory_geff(node_df, edge_df)
 
         assert result["node_ids"].shape == (0,)
         assert result["edge_ids"].shape == (0, 2)
@@ -327,7 +292,7 @@ class Test_dataframes_to_geff:
     def test_all_edge_cases(self, sample_dataframes, expected_memory_geff):
         """Manually constructed input DataFrames produce expected InMemoryGeff."""
         node_df, edge_df = sample_dataframes
-        result = dataframes_to_memory_geff(node_df, edge_df, directed=True)
+        result = _dataframes_to_memory_geff(node_df, edge_df, directed=True)
         expected = expected_memory_geff
 
         assert result["metadata"].directed is True

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -261,6 +261,22 @@ class Test_dataframes_to_geff:
         np.testing.assert_array_equal(result["node_props"]["flag"]["values"], [True, False, False])
         np.testing.assert_array_equal(result["node_props"]["flag"]["missing"], [False, True, False])
 
+    def test_missing_node_id_column(self):
+        """Should raise ValueError when node_df is missing the ID column."""
+        node_df = pd.DataFrame({"x": [1.0, 2.0]})
+        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
+
+        with pytest.raises(ValueError, match="node_df must contain a 'id' column"):
+            dataframes_to_memory_geff(node_df, edge_df)
+
+    def test_missing_edge_columns(self):
+        """Should raise ValueError when edge_df is missing source/target columns."""
+        node_df = pd.DataFrame({"id": [0, 1]})
+        edge_df = pd.DataFrame({"src": [0], "tgt": [1]})
+
+        with pytest.raises(ValueError, match="edge_df must contain"):
+            dataframes_to_memory_geff(node_df, edge_df)
+
     def test_empty_dataframes(self):
         """Empty DataFrames should produce valid InMemoryGeff with empty arrays."""
         node_df = pd.DataFrame({"id": pd.Series(dtype=int)})

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -4,7 +4,12 @@ import zarr
 try:
     import pandas as pd
 
-    from geff.convert._dataframe import geff_to_csv, geff_to_dataframes
+    from geff.convert._dataframe import (
+        dataframes_to_geff,
+        dataframes_to_memory_geff,
+        geff_to_csv,
+        geff_to_dataframes,
+    )
 except ImportError:
     pytest.skip("geff[pandas] not installed", allow_module_level=True)
 
@@ -14,6 +19,7 @@ import numpy as np
 import pytest
 
 from geff import _path
+from geff.core_io._base_read import read_to_memory
 from geff.testing.data import create_mock_geff, create_simple_2d_geff, create_simple_3d_geff
 
 
@@ -197,3 +203,98 @@ class Test_geff_to_csv:
         geff_to_csv(store_2d, out_path, overwrite=True)
         df = pd.read_csv(str(out_path.with_suffix("")) + "-nodes.csv")
         assert "z" not in df.columns
+
+
+class Test_dataframes_to_geff:
+    def test_round_trip(self):
+        """geff -> dataframes -> geff should preserve data."""
+        store, original = create_simple_3d_geff()
+        node_df, edge_df = geff_to_dataframes(store)
+
+        result = dataframes_to_memory_geff(node_df, edge_df, directed=original["metadata"].directed)
+
+        np.testing.assert_array_equal(result["node_ids"], original["node_ids"])
+        np.testing.assert_array_equal(result["edge_ids"], original["edge_ids"])
+        for name in original["node_props"]:
+            np.testing.assert_array_equal(
+                result["node_props"][name]["values"],
+                original["node_props"][name]["values"],
+            )
+        for name in original["edge_props"]:
+            np.testing.assert_array_equal(
+                result["edge_props"][name]["values"],
+                original["edge_props"][name]["values"],
+            )
+
+    def test_missing_values(self):
+        """NaN values in DataFrame should produce missing masks."""
+        node_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2],
+                "score": [1.0, np.nan, 3.0],
+            }
+        )
+        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
+
+        result = dataframes_to_memory_geff(node_df, edge_df)
+
+        assert result["node_props"]["score"]["missing"] is not None
+        np.testing.assert_array_equal(
+            result["node_props"]["score"]["missing"], [False, True, False]
+        )
+        np.testing.assert_array_equal(result["node_props"]["score"]["values"], [1.0, 0, 3.0])
+
+    def test_boolean_column_with_missing(self):
+        """Boolean columns with NaN should preserve bool dtype."""
+        node_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2],
+                "flag": pd.array([True, pd.NA, False], dtype=pd.BooleanDtype()),
+            }
+        )
+        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
+
+        result = dataframes_to_memory_geff(node_df, edge_df)
+
+        assert result["node_props"]["flag"]["values"].dtype == np.bool_
+        np.testing.assert_array_equal(result["node_props"]["flag"]["values"], [True, False, False])
+        np.testing.assert_array_equal(result["node_props"]["flag"]["missing"], [False, True, False])
+
+    def test_empty_dataframes(self):
+        """Empty DataFrames should produce valid InMemoryGeff with empty arrays."""
+        node_df = pd.DataFrame({"id": pd.Series(dtype=int)})
+        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
+
+        result = dataframes_to_memory_geff(node_df, edge_df)
+
+        assert result["node_ids"].shape == (0,)
+        assert result["edge_ids"].shape == (0, 2)
+        assert result["node_props"] == {}
+        assert result["edge_props"] == {}
+
+    def test_write_round_trip(self):
+        """dataframes_to_geff -> read_to_memory should preserve data."""
+        node_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2],
+                "x": [1.0, 2.0, 3.0],
+                "y": [4.0, 5.0, 6.0],
+            }
+        )
+        edge_df = pd.DataFrame(
+            {
+                "source": [0, 1],
+                "target": [1, 2],
+                "weight": [0.5, 0.8],
+            }
+        )
+
+        store = zarr.storage.MemoryStore()
+        dataframes_to_geff(node_df, edge_df, store)
+
+        result = read_to_memory(store)
+        np.testing.assert_array_equal(result["node_ids"], [0, 1, 2])
+        np.testing.assert_array_equal(result["edge_ids"], [[0, 1], [1, 2]])
+        np.testing.assert_array_equal(result["node_props"]["x"]["values"], [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(result["node_props"]["y"]["values"], [4.0, 5.0, 6.0])
+        np.testing.assert_array_equal(result["edge_props"]["weight"]["values"], [0.5, 0.8])

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -5,6 +5,7 @@ try:
     import pandas as pd
 
     from geff.convert._dataframe import (
+        csv_to_geff,
         dataframes_to_geff,
         dataframes_to_memory_geff,
         geff_to_csv,
@@ -298,3 +299,28 @@ class Test_dataframes_to_geff:
         np.testing.assert_array_equal(result["node_props"]["x"]["values"], [1.0, 2.0, 3.0])
         np.testing.assert_array_equal(result["node_props"]["y"]["values"], [4.0, 5.0, 6.0])
         np.testing.assert_array_equal(result["edge_props"]["weight"]["values"], [0.5, 0.8])
+
+
+class Test_csv_to_geff:
+    def test_round_trip(self, tmp_path):
+        """geff_to_csv -> csv_to_geff should preserve data."""
+        store_in, original = create_simple_3d_geff()
+        out_path = tmp_path / "test"
+        geff_to_csv(store_in, out_path)
+
+        store_out = zarr.storage.MemoryStore()
+        csv_to_geff(
+            f"{out_path}-nodes.csv",
+            f"{out_path}-edges.csv",
+            store_out,
+            directed=original["metadata"].directed,
+        )
+
+        result = read_to_memory(store_out)
+        np.testing.assert_array_equal(result["node_ids"], original["node_ids"])
+        np.testing.assert_array_equal(result["edge_ids"], original["edge_ids"])
+        for name in original["node_props"]:
+            np.testing.assert_allclose(
+                result["node_props"][name]["values"],
+                original["node_props"][name]["values"],
+            )

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -368,6 +368,11 @@ class Test_dataframes_to_geff:
             )
             if expected["edge_props"][name]["missing"] is None:
                 assert result["edge_props"][name]["missing"] is None
+            else:
+                np.testing.assert_array_equal(
+                    result["edge_props"][name]["missing"],
+                    expected["edge_props"][name]["missing"],
+                )
 
 
 class Test_csv_to_geff:
@@ -406,6 +411,13 @@ class Test_csv_to_geff:
                 result["edge_props"][name]["values"],
                 expected["edge_props"][name]["values"],
             )
+            if expected["edge_props"][name]["missing"] is None:
+                assert result["edge_props"][name]["missing"] is None
+            else:
+                np.testing.assert_array_equal(
+                    result["edge_props"][name]["missing"],
+                    expected["edge_props"][name]["missing"],
+                )
 
         # Unnamed: column must have been filtered out
         assert all(not k.startswith("Unnamed:") for k in result["node_props"])

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -7,7 +7,6 @@ try:
     from geff.convert._dataframe import (
         _infer_int_dtype,
         csv_to_geff,
-        dataframes_to_geff,
         dataframes_to_memory_geff,
         geff_to_csv,
         geff_to_dataframes,
@@ -241,61 +240,62 @@ class Test_geff_to_csv:
         assert "z" not in df.columns
 
 
+@pytest.fixture()
+def sample_dataframes():
+    """Node and edge DataFrames covering multiple dtypes and missing values."""
+    node_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3, 4, 5],
+            "x": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "label": ["a", "b", "c", "d", "e", "f"],
+            "flag": pd.array([True, False, pd.NA, True, False, True], dtype=pd.BooleanDtype()),
+            "score": [10.0, np.nan, 30.0, 40.0, 50.0, 60.0],
+        }
+    )
+    edge_df = pd.DataFrame(
+        {
+            "source": [0, 1, 2, 3],
+            "target": [1, 2, 3, 4],
+            "weight": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    return node_df, edge_df
+
+
+@pytest.fixture()
+def expected_memory_geff():
+    """Manually constructed expected InMemoryGeff for the sample DataFrames."""
+    return {
+        "node_ids": np.array([0, 1, 2, 3, 4, 5], dtype=np.uint8),
+        "edge_ids": np.array([[0, 1], [1, 2], [2, 3], [3, 4]], dtype=np.uint8),
+        "node_props": {
+            "x": {
+                "values": np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+                "missing": None,
+            },
+            "label": {
+                "values": np.array(["a", "b", "c", "d", "e", "f"]),
+                "missing": None,
+            },
+            "flag": {
+                "values": np.array([True, False, False, True, False, True]),
+                "missing": np.array([False, False, True, False, False, False]),
+            },
+            "score": {
+                "values": np.array([10.0, 0.0, 30.0, 40.0, 50.0, 60.0]),
+                "missing": np.array([False, True, False, False, False, False]),
+            },
+        },
+        "edge_props": {
+            "weight": {
+                "values": np.array([0.1, 0.2, 0.3, 0.4]),
+                "missing": None,
+            },
+        },
+    }
+
+
 class Test_dataframes_to_geff:
-    def test_round_trip(self):
-        """geff -> dataframes -> geff should preserve data."""
-        store, original = create_simple_3d_geff()
-        node_df, edge_df = geff_to_dataframes(store)
-
-        result = dataframes_to_memory_geff(node_df, edge_df, directed=original["metadata"].directed)
-
-        np.testing.assert_array_equal(result["node_ids"], original["node_ids"])
-        np.testing.assert_array_equal(result["edge_ids"], original["edge_ids"])
-        for name in original["node_props"]:
-            np.testing.assert_array_equal(
-                result["node_props"][name]["values"],
-                original["node_props"][name]["values"],
-            )
-        for name in original["edge_props"]:
-            np.testing.assert_array_equal(
-                result["edge_props"][name]["values"],
-                original["edge_props"][name]["values"],
-            )
-
-    def test_missing_values(self):
-        """NaN values in DataFrame should produce missing masks."""
-        node_df = pd.DataFrame(
-            {
-                "id": [0, 1, 2],
-                "score": [1.0, np.nan, 3.0],
-            }
-        )
-        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
-
-        result = dataframes_to_memory_geff(node_df, edge_df)
-
-        assert result["node_props"]["score"]["missing"] is not None
-        np.testing.assert_array_equal(
-            result["node_props"]["score"]["missing"], [False, True, False]
-        )
-        np.testing.assert_array_equal(result["node_props"]["score"]["values"], [1.0, 0, 3.0])
-
-    def test_boolean_column_with_missing(self):
-        """Boolean columns with NaN should preserve bool dtype."""
-        node_df = pd.DataFrame(
-            {
-                "id": [0, 1, 2],
-                "flag": pd.array([True, pd.NA, False], dtype=pd.BooleanDtype()),
-            }
-        )
-        edge_df = pd.DataFrame({"source": pd.Series(dtype=int), "target": pd.Series(dtype=int)})
-
-        result = dataframes_to_memory_geff(node_df, edge_df)
-
-        assert result["node_props"]["flag"]["values"].dtype == np.bool_
-        np.testing.assert_array_equal(result["node_props"]["flag"]["values"], [True, False, False])
-        np.testing.assert_array_equal(result["node_props"]["flag"]["missing"], [False, True, False])
-
     def test_missing_node_id_column(self):
         """Should raise ValueError when node_df is missing the ID column."""
         node_df = pd.DataFrame({"x": [1.0, 2.0]})
@@ -324,54 +324,89 @@ class Test_dataframes_to_geff:
         assert result["node_props"] == {}
         assert result["edge_props"] == {}
 
-    def test_write_round_trip(self):
-        """dataframes_to_geff -> read_to_memory should preserve data."""
-        node_df = pd.DataFrame(
-            {
-                "id": [0, 1, 2],
-                "x": [1.0, 2.0, 3.0],
-                "y": [4.0, 5.0, 6.0],
-            }
-        )
-        edge_df = pd.DataFrame(
-            {
-                "source": [0, 1],
-                "target": [1, 2],
-                "weight": [0.5, 0.8],
-            }
-        )
+    def test_all_edge_cases(self, sample_dataframes, expected_memory_geff):
+        """Manually constructed input DataFrames produce expected InMemoryGeff."""
+        node_df, edge_df = sample_dataframes
+        result = dataframes_to_memory_geff(node_df, edge_df, directed=True)
+        expected = expected_memory_geff
 
-        store = zarr.storage.MemoryStore()
-        dataframes_to_geff(node_df, edge_df, store)
+        assert result["metadata"].directed is True
 
-        result = read_to_memory(store)
-        np.testing.assert_array_equal(result["node_ids"], [0, 1, 2])
-        np.testing.assert_array_equal(result["edge_ids"], [[0, 1], [1, 2]])
-        np.testing.assert_array_equal(result["node_props"]["x"]["values"], [1.0, 2.0, 3.0])
-        np.testing.assert_array_equal(result["node_props"]["y"]["values"], [4.0, 5.0, 6.0])
-        np.testing.assert_array_equal(result["edge_props"]["weight"]["values"], [0.5, 0.8])
+        np.testing.assert_array_equal(result["node_ids"], expected["node_ids"])
+        assert result["node_ids"].dtype == expected["node_ids"].dtype
+
+        np.testing.assert_array_equal(result["edge_ids"], expected["edge_ids"])
+        assert result["edge_ids"].dtype == expected["edge_ids"].dtype
+
+        assert set(result["node_props"].keys()) == set(expected["node_props"].keys())
+        for name in expected["node_props"]:
+            np.testing.assert_array_equal(
+                result["node_props"][name]["values"],
+                expected["node_props"][name]["values"],
+            )
+            assert (
+                result["node_props"][name]["values"].dtype
+                == expected["node_props"][name]["values"].dtype
+            )
+            if expected["node_props"][name]["missing"] is None:
+                assert result["node_props"][name]["missing"] is None
+            else:
+                np.testing.assert_array_equal(
+                    result["node_props"][name]["missing"],
+                    expected["node_props"][name]["missing"],
+                )
+
+        assert set(result["edge_props"].keys()) == set(expected["edge_props"].keys())
+        for name in expected["edge_props"]:
+            np.testing.assert_array_equal(
+                result["edge_props"][name]["values"],
+                expected["edge_props"][name]["values"],
+            )
+            assert (
+                result["edge_props"][name]["values"].dtype
+                == expected["edge_props"][name]["values"].dtype
+            )
+            if expected["edge_props"][name]["missing"] is None:
+                assert result["edge_props"][name]["missing"] is None
 
 
 class Test_csv_to_geff:
-    def test_round_trip(self, tmp_path):
-        """geff_to_csv -> csv_to_geff should preserve data."""
-        store_in, original = create_simple_3d_geff()
-        out_path = tmp_path / "test"
-        geff_to_csv(store_in, out_path)
+    def test_end_to_end(self, tmp_path, sample_dataframes, expected_memory_geff):
+        """CSV files with an Unnamed: column should produce correct geff on disk."""
+        node_df, edge_df = sample_dataframes
 
-        store_out = zarr.storage.MemoryStore()
-        csv_to_geff(
-            f"{out_path}-nodes.csv",
-            f"{out_path}-edges.csv",
-            store_out,
-            directed=original["metadata"].directed,
-        )
+        # Write CSVs with a pandas-style index column (Unnamed: 0)
+        node_df.to_csv(tmp_path / "nodes.csv")
+        edge_df.to_csv(tmp_path / "edges.csv")
 
-        result = read_to_memory(store_out)
-        np.testing.assert_array_equal(result["node_ids"], original["node_ids"])
-        np.testing.assert_array_equal(result["edge_ids"], original["edge_ids"])
-        for name in original["node_props"]:
-            np.testing.assert_allclose(
+        store_path = str(tmp_path / "output.zarr")
+        csv_to_geff(tmp_path / "nodes.csv", tmp_path / "edges.csv", store_path, directed=True)
+
+        result = read_to_memory(store_path)
+        expected = expected_memory_geff
+
+        np.testing.assert_array_equal(result["node_ids"], expected["node_ids"])
+        np.testing.assert_array_equal(result["edge_ids"], expected["edge_ids"])
+
+        for name in expected["node_props"]:
+            np.testing.assert_array_equal(
                 result["node_props"][name]["values"],
-                original["node_props"][name]["values"],
+                expected["node_props"][name]["values"],
             )
+            if expected["node_props"][name]["missing"] is None:
+                assert result["node_props"][name]["missing"] is None
+            else:
+                np.testing.assert_array_equal(
+                    result["node_props"][name]["missing"],
+                    expected["node_props"][name]["missing"],
+                )
+
+        for name in expected["edge_props"]:
+            np.testing.assert_array_equal(
+                result["edge_props"][name]["values"],
+                expected["edge_props"][name]["values"],
+            )
+
+        # Unnamed: column must have been filtered out
+        assert all(not k.startswith("Unnamed:") for k in result["node_props"])
+        assert all(not k.startswith("Unnamed:") for k in result["edge_props"])

--- a/packages/geff/tests/test_convert/test_dataframe.py
+++ b/packages/geff/tests/test_convert/test_dataframe.py
@@ -5,6 +5,7 @@ try:
     import pandas as pd
 
     from geff.convert._dataframe import (
+        _infer_int_dtype,
         csv_to_geff,
         dataframes_to_geff,
         dataframes_to_memory_geff,
@@ -22,6 +23,40 @@ import pytest
 from geff import _path
 from geff.core_io._base_read import read_to_memory
 from geff.testing.data import create_mock_geff, create_simple_2d_geff, create_simple_3d_geff
+
+
+class Test_infer_int_dtype:
+    def test_small_unsigned(self):
+        values = np.array([0, 1, 255])
+        assert _infer_int_dtype(values) == np.dtype(np.uint8)
+
+    def test_uint16(self):
+        values = np.array([0, 256])
+        assert _infer_int_dtype(values) == np.dtype(np.uint16)
+
+    def test_uint32(self):
+        values = np.array([0, 2**16])
+        assert _infer_int_dtype(values) == np.dtype(np.uint32)
+
+    def test_uint64(self):
+        values = np.array([0, 2**32])
+        assert _infer_int_dtype(values) == np.dtype(np.uint64)
+
+    def test_negative_int8(self):
+        values = np.array([-1, 0, 127])
+        assert _infer_int_dtype(values) == np.dtype(np.int8)
+
+    def test_negative_int16(self):
+        values = np.array([-129, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int16)
+
+    def test_negative_int32(self):
+        values = np.array([-(2**15) - 1, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int32)
+
+    def test_negative_int64(self):
+        values = np.array([-(2**31) - 1, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int64)
 
 
 class Test_geff_to_dataframes:

--- a/packages/geff/tests/test_core_io/test_base_write.py
+++ b/packages/geff/tests/test_core_io/test_base_write.py
@@ -281,6 +281,16 @@ def test_dict_prop_to_arr(dict_data, data_type, expected) -> None:
     assert values.dtype == ex_values.dtype
 
 
+def test_dict_prop_to_arr_missing_on_all(dict_data) -> None:
+    """Property not present on any element should warn and default to 0."""
+    with pytest.warns(UserWarning, match="not present on any graph elements"):
+        props_dict = dict_props_to_arr(dict_data, ["nonexistent"])
+    values = props_dict["nonexistent"]["values"]
+    missing = props_dict["nonexistent"]["missing"]
+    np.testing.assert_array_equal(values, [0, 0, 0])
+    np.testing.assert_array_equal(missing, [True, True, True])
+
+
 class Test_write_dicts:
     def test_node_ids_not_int(self):
         store = zarr.storage.MemoryStore()

--- a/packages/geff/tests/test_core_io/test_base_write.py
+++ b/packages/geff/tests/test_core_io/test_base_write.py
@@ -42,7 +42,7 @@ def _tmp_metadata():
 @pytest.fixture
 def dict_data():
     data = [
-        (0, {"num": 1, "str": "category"}),
+        (0, {"num": 1, "str": "category", "flag": True}),
         (127, {"num": 5, "str_arr": ["test", "string"]}),
         (1, {"num": 6, "num_arr": [1, 2]}),
     ]
@@ -265,6 +265,7 @@ class TestWriteArrays:
         ("str", (["category", "", ""], [0, 1, 1])),
         ("num_arr", ([[1, 2], [1, 2], [1, 2]], [1, 1, 0])),
         ("str_arr", ([["test", "string"], ["test", "string"], ["test", "string"]], [1, 0, 1])),
+        ("flag", ([True, False, False], [0, 1, 1])),
     ],
 )
 def test_dict_prop_to_arr(dict_data, data_type, expected) -> None:
@@ -277,6 +278,7 @@ def test_dict_prop_to_arr(dict_data, data_type, expected) -> None:
 
     np.testing.assert_array_equal(missing, ex_missing)
     np.testing.assert_array_equal(values, ex_values)
+    assert values.dtype == ex_values.dtype
 
 
 class Test_write_dicts:

--- a/packages/geff/tests/test_core_io/test_core_utils.py
+++ b/packages/geff/tests/test_core_io/test_core_utils.py
@@ -9,10 +9,10 @@ import zarr.storage
 from geff import _path
 from geff.core_io._base_write import write_arrays
 from geff.core_io._utils import (
-    _default_for_value,
     _detect_zarr_spec_version,
     check_for_geff,
     construct_props,
+    default_for_value,
     delete_geff,
     open_storelike,
     setup_zarr_group,
@@ -43,7 +43,7 @@ from geff.testing.data import create_simple_2d_geff
     ],
 )
 def test_default_for_value(value, expected):
-    result = _default_for_value(value)
+    result = default_for_value(value)
     assert result == expected
     assert type(result) is type(expected)
 

--- a/packages/geff/tests/test_core_io/test_core_utils.py
+++ b/packages/geff/tests/test_core_io/test_core_utils.py
@@ -11,6 +11,7 @@ from geff.core_io._base_write import write_arrays
 from geff.core_io._utils import (
     _detect_zarr_spec_version,
     check_for_geff,
+    construct_props,
     delete_geff,
     open_storelike,
     setup_zarr_group,
@@ -100,6 +101,34 @@ class TestZarrV2Warnings:
     def test_warn_if_writing_zarr_format_3(self, tmp_path: Path):
         with pytest.warns(UserWarning, match="Requesting zarr spec v3 with zarr-python v2"):
             setup_zarr_group(tmp_path / "test.zarr", zarr_format=3)
+
+
+class Test_construct_props:
+    @pytest.mark.parametrize(
+        ("values", "expected_values", "expected_missing", "expected_dtype"),
+        [
+            ([True, None, False], [True, False, False], [False, True, False], np.bool_),
+            ([1, None, 3], [1, 0, 3], [False, True, False], np.int64),
+            ([1.5, None, 3.5], [1.5, 0, 3.5], [False, True, False], np.float64),
+            (["a", None, "c"], ["a", "", "c"], [False, True, False], np.dtype("<U1")),
+            ([1, 2, 3], [1, 2, 3], None, np.int64),
+            ([True, False, True], [True, False, True], None, np.bool_),
+        ],
+    )
+    def test_values_and_missing(self, values, expected_values, expected_missing, expected_dtype):
+        result = construct_props(values)
+        np.testing.assert_array_equal(result["values"], np.array(expected_values))
+        assert result["values"].dtype == expected_dtype
+        if expected_missing is None:
+            assert result["missing"] is None
+        else:
+            np.testing.assert_array_equal(result["missing"], np.array(expected_missing, dtype=bool))
+
+    def test_all_none(self):
+        with pytest.warns(UserWarning, match="All values are None"):
+            result = construct_props([None, None, None])
+        np.testing.assert_array_equal(result["values"], np.array([0, 0, 0]))
+        np.testing.assert_array_equal(result["missing"], np.array([True, True, True]))
 
 
 class Test_delete_geff:

--- a/packages/geff/tests/test_core_io/test_core_utils.py
+++ b/packages/geff/tests/test_core_io/test_core_utils.py
@@ -10,6 +10,7 @@ from geff import _path
 from geff.core_io._base_write import write_arrays
 from geff.core_io._utils import (
     _detect_zarr_spec_version,
+    _infer_int_dtype,
     check_for_geff,
     construct_props,
     default_for_value,
@@ -132,16 +133,50 @@ class TestZarrV2Warnings:
             setup_zarr_group(tmp_path / "test.zarr", zarr_format=3)
 
 
+class Test_infer_int_dtype:
+    def test_small_unsigned(self):
+        values = np.array([0, 1, 255])
+        assert _infer_int_dtype(values) == np.dtype(np.uint8)
+
+    def test_uint16(self):
+        values = np.array([0, 256])
+        assert _infer_int_dtype(values) == np.dtype(np.uint16)
+
+    def test_uint32(self):
+        values = np.array([0, 2**16])
+        assert _infer_int_dtype(values) == np.dtype(np.uint32)
+
+    def test_uint64(self):
+        values = np.array([0, 2**32])
+        assert _infer_int_dtype(values) == np.dtype(np.uint64)
+
+    def test_negative_int8(self):
+        values = np.array([-1, 0, 127])
+        assert _infer_int_dtype(values) == np.dtype(np.int8)
+
+    def test_negative_int16(self):
+        values = np.array([-129, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int16)
+
+    def test_negative_int32(self):
+        values = np.array([-(2**15) - 1, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int32)
+
+    def test_negative_int64(self):
+        values = np.array([-(2**31) - 1, 0])
+        assert _infer_int_dtype(values) == np.dtype(np.int64)
+
+
 class Test_construct_props:
     @pytest.mark.parametrize(
         ("values", "expected_values", "expected_missing", "expected_dtype"),
         [
             # Python native types
             ([True, None, False], [True, False, False], [False, True, False], np.bool_),
-            ([1, None, 3], [1, 0, 3], [False, True, False], np.int64),
+            ([1, None, 3], [1, 0, 3], [False, True, False], np.uint8),
             ([1.5, None, 3.5], [1.5, 0, 3.5], [False, True, False], np.float64),
             (["a", None, "c"], ["a", "", "c"], [False, True, False], np.dtype("<U1")),
-            ([1, 2, 3], [1, 2, 3], None, np.int64),
+            ([1, 2, 3], [1, 2, 3], None, np.uint8),
             ([True, False, True], [True, False, True], None, np.bool_),
             # numpy scalar types (e.g. from pandas iteration)
             (
@@ -150,7 +185,7 @@ class Test_construct_props:
                 [False, True, False],
                 np.bool_,
             ),
-            ([np.int64(1), None, np.int64(3)], [1, 0, 3], [False, True, False], np.int64),
+            ([np.int64(1), None, np.int64(3)], [1, 0, 3], [False, True, False], np.uint8),
             (
                 [np.float32(1.5), None, np.float32(3.5)],
                 [1.5, 0, 3.5],

--- a/packages/geff/tests/test_core_io/test_core_utils.py
+++ b/packages/geff/tests/test_core_io/test_core_utils.py
@@ -9,6 +9,7 @@ import zarr.storage
 from geff import _path
 from geff.core_io._base_write import write_arrays
 from geff.core_io._utils import (
+    _default_for_value,
     _detect_zarr_spec_version,
     check_for_geff,
     construct_props,
@@ -17,6 +18,34 @@ from geff.core_io._utils import (
     setup_zarr_group,
 )
 from geff.testing.data import create_simple_2d_geff
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Python native types
+        (True, False),
+        (False, False),
+        (1, 0),
+        (3.14, 0),
+        ("hello", ""),
+        # numpy scalar types (preserves dtype)
+        (np.bool_(True), np.bool_(False)),
+        (np.bool_(False), np.bool_(False)),
+        (np.int64(5), np.int64(0)),
+        (np.int32(5), np.int32(0)),
+        (np.int16(5), np.int16(0)),
+        (np.uint8(5), np.uint8(0)),
+        (np.float64(2.5), np.float64(0)),
+        (np.float32(2.5), np.float32(0)),
+        # fallback: returns value itself
+        ([1, 2, 3], [1, 2, 3]),
+    ],
+)
+def test_default_for_value(value, expected):
+    result = _default_for_value(value)
+    assert result == expected
+    assert type(result) is type(expected)
 
 
 @pytest.mark.skipif(zarr.__version__.startswith("2"), reason="tests for zarr-python>=v3 only")
@@ -107,12 +136,27 @@ class Test_construct_props:
     @pytest.mark.parametrize(
         ("values", "expected_values", "expected_missing", "expected_dtype"),
         [
+            # Python native types
             ([True, None, False], [True, False, False], [False, True, False], np.bool_),
             ([1, None, 3], [1, 0, 3], [False, True, False], np.int64),
             ([1.5, None, 3.5], [1.5, 0, 3.5], [False, True, False], np.float64),
             (["a", None, "c"], ["a", "", "c"], [False, True, False], np.dtype("<U1")),
             ([1, 2, 3], [1, 2, 3], None, np.int64),
             ([True, False, True], [True, False, True], None, np.bool_),
+            # numpy scalar types (e.g. from pandas iteration)
+            (
+                [np.bool_(True), None, np.bool_(False)],
+                [True, False, False],
+                [False, True, False],
+                np.bool_,
+            ),
+            ([np.int64(1), None, np.int64(3)], [1, 0, 3], [False, True, False], np.int64),
+            (
+                [np.float32(1.5), None, np.float32(3.5)],
+                [1.5, 0, 3.5],
+                [False, True, False],
+                np.float32,
+            ),
         ],
     )
     def test_values_and_missing(self, values, expected_values, expected_missing, expected_dtype):

--- a/packages/geff/tests/test_core_io/test_core_utils.py
+++ b/packages/geff/tests/test_core_io/test_core_utils.py
@@ -27,7 +27,7 @@ from geff.testing.data import create_simple_2d_geff
         (True, False),
         (False, False),
         (1, 0),
-        (3.14, 0),
+        (3.14, 0.0),
         ("hello", ""),
         # numpy scalar types (preserves dtype)
         (np.bool_(True), np.bool_(False)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ filterwarnings = [
     # "ignore:Some message:SomeCategory",
     "ignore:.*skipping conversion test:ImportWarning:networkx",
     "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar.",
+    "ignore:Pyarrow will become a required dependency:DeprecationWarning",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ filterwarnings = [
     # "ignore:Some message:SomeCategory",
     "ignore:.*skipping conversion test:ImportWarning:networkx",
     "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar.",
-    "ignore:Pyarrow will become a required dependency:DeprecationWarning",
+    "ignore:(?s).*Pyarrow will become a required dependency:DeprecationWarning",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ filterwarnings = [
     "ignore:.*skipping conversion test:ImportWarning:networkx",
     "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar.",
     "ignore:(?s).*Pyarrow will become a required dependency:DeprecationWarning",
+    "ignore:invalid value encountered in cast:RuntimeWarning",
 ]
 
 


### PR DESCRIPTION
# Proposed Change
Convert a dataframe to a GEFF (and thus a csv read with pandas)
Closes #319 
@AnniekStok This would hopefully take over the functionality of your funtracks PR https://github.com/funkelab/funtracks/pull/186 - we can just call dataframes_to_memory_geff after splitting the edges into their own df. Current implementation doesn't support list elements, but I think we should just write them into separate columns (unsquish on write) and then manipulate the InMemoryGeff after calling dataframes_to_memory_geff to resquish them as needed. Just need a way to save which ones should be squished, which can go in custom metadata.

Open questions: Should I add a benchmark? Should I implement the squishing? If so, how should I let the user tell us which columns to squish on read - optional argument of dict from new name to old column names, save GeffMetadata with csvs and add that dict to the extras, both as options?

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- New feature or enhancement

Which topics does your change affect? Delete those that do not apply.
- Convert
- Core io

# Checklist

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).

# Further Comments
I would love at least the default value refactoring to live in GEFF, along with the construct_props helper. If we keep the dataframe specific code in funtracks, at least we can avoid duplicating constructing the values and missing arrays with the correct dtype of default values.