### PR TITLE
GEFF IO improvement

### DIFF
--- a/packages/geff/src/geff/core_io/_base_read.py
+++ b/packages/geff/src/geff/core_io/_base_read.py
@@ -187,7 +187,7 @@ class GeffReader:
         indices = np.where(mask)[0] if mask is not None else None
 
         dtype = np.dtype(prop_metadata.dtype)
-        values_dtype = np.uint64 if prop_metadata.varlength else dtype
+        values_dtype = np.dtype(np.uint64) if prop_metadata.varlength else dtype
         values = self._load_zarr_subset(zarr_prop[_path.VALUES], indices, dtype=values_dtype)
 
         if _path.MISSING in zarr_prop:

--- a/packages/geff/src/geff/core_io/_base_read.py
+++ b/packages/geff/src/geff/core_io/_base_read.py
@@ -133,6 +133,35 @@ class GeffReader:
             prop_dict[_path.DATA] = expect_array(prop_group, _path.DATA, prop_type)
         return prop_dict
 
+    @staticmethod
+    def _load_zarr_subset(
+        zarr_arr: zarr.Array,
+        indices: NDArray[np.intp] | None,
+        dtype: np.dtype | None = None,
+    ) -> NDArray:
+        """Load a subset of a zarr array using integer indices.
+
+        Uses ``oindex`` (orthogonal indexing) which is significantly faster than
+        boolean-mask indexing for sparse selections, because zarr only needs to
+        read the chunks that contain the requested indices.
+
+        Args:
+            zarr_arr: The zarr array to read from.
+            indices: Integer indices to select, or ``None`` to load the full array.
+            dtype: Optional dtype to cast the result to.
+
+        Returns:
+            A numpy array with the selected data.
+        """
+        if indices is None:
+            data = zarr_arr[:]
+        elif len(indices) == 0:
+            shape = (0, *zarr_arr.shape[1:])
+            return np.empty(shape, dtype=dtype or zarr_arr.dtype)
+        else:
+            data = zarr_arr.oindex[indices]
+        return np.asarray(data, dtype=dtype) if dtype is not None else np.asarray(data)
+
     def _load_prop_to_memory(
         self,
         zarr_prop: ZarrPropDict,
@@ -155,24 +184,23 @@ class GeffReader:
         Returns:
             PropDictNpArray: The property loaded into memory as "values" and "missing" arrays.
         """
+        indices = np.where(mask)[0] if mask is not None else None
+
         dtype = np.dtype(prop_metadata.dtype)
         values_dtype = np.uint64 if prop_metadata.varlength else dtype
-        values = np.array(
-            zarr_prop[_path.VALUES][mask.tolist() if mask is not None else ...],
-            dtype=values_dtype,
-        )
+        values = self._load_zarr_subset(zarr_prop[_path.VALUES], indices, dtype=values_dtype)
+
         if _path.MISSING in zarr_prop:
-            missing = np.array(
-                zarr_prop[_path.MISSING][mask.tolist() if mask is not None else ...],
-                dtype=bool,
+            missing = self._load_zarr_subset(
+                zarr_prop[_path.MISSING], indices, dtype=np.dtype(bool)
             )
         else:
             missing = None
+
         if _path.DATA in zarr_prop:
-            data = np.array(
-                zarr_prop[_path.DATA][mask.tolist() if mask is not None else ...],
-                dtype=dtype,
-            )
+            # DATA is a flat 1D array of concatenated varlength values; it cannot
+            # be subset by the per-element mask — always load it in full.
+            data = np.asarray(zarr_prop[_path.DATA][:], dtype=dtype)
         else:
             data = None
 
@@ -222,14 +250,16 @@ class GeffReader:
                 }
                 ```
         """
-        nodes = np.array(self.nodes[node_mask.tolist() if node_mask is not None else ...])
+        node_indices = np.where(node_mask)[0] if node_mask is not None else None
+        nodes = self._load_zarr_subset(self.nodes, node_indices)
+
         node_props: dict[str, PropDictNpArray] = {}
         for name, props in self.node_props.items():
             prop_metadata = self.metadata.node_props_metadata[name]
             node_props[name] = self._load_prop_to_memory(props, node_mask, prop_metadata)
 
-        # remove edges if any of it's nodes has been masked
-        edges = np.array(self.edges[:])
+        # remove edges if any of its nodes has been masked
+        edges = np.asarray(self.edges[:])
         if node_mask is not None:
             edge_mask_removed_nodes = np.isin(edges, nodes).all(axis=1)
             if edge_mask is not None:

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -307,6 +307,73 @@ def write_arrays(
             raise ValueError(e.args[0] + message) from e
 
 
+_TARGET_CHUNK_BYTES = 1 << 23  # 8 MiB — power-of-two, close to 10 MB
+
+
+def _compute_first_dim_chunk(shape: tuple[int, ...], itemsize: int) -> int:
+    """Return a power-of-two first-dimension chunk size targeting ~8 MiB per chunk.
+
+    Trailing dimensions are kept whole so only the first dimension is chunked.
+    """
+    row_bytes = int(np.prod(shape[1:])) * itemsize if len(shape) > 1 else itemsize
+    n_rows = _TARGET_CHUNK_BYTES // max(row_bytes, 1)
+    # Round down to nearest power of two
+    if n_rows >= 1:
+        n_rows = 1 << (n_rows.bit_length() - 1)
+    return max(1, min(shape[0], n_rows))
+
+
+def _write_zarr_array(
+    group: Any,
+    path: str,
+    data: np.ndarray,
+) -> None:
+    """Write a numpy array to a zarr group with sensible chunking.
+
+    Chunks only along the first dimension (trailing dimensions are kept whole)
+    with a power-of-two first-dimension size targeting ~8 MiB per chunk.
+
+    On zarr v3 sharding is used so every array becomes a single file: the shard
+    (outer chunk) spans the entire first dimension while inner sub-chunks are
+    ~8 MiB each.
+
+    Args:
+        group: The zarr group to write into.
+        path: The path within the group.
+        data: The numpy array to write.
+    """
+    import zarr as _zarr
+
+    if data.shape[0] == 0:
+        group[path] = data
+        return
+
+    first_dim = _compute_first_dim_chunk(data.shape, data.dtype.itemsize)
+    chunks = (first_dim, *data.shape[1:])
+
+    use_sharding = (
+        not _zarr.__version__.startswith("2")
+        and hasattr(group, "metadata")
+        and getattr(group.metadata, "zarr_format", 2) == 3
+    )
+
+    if use_sharding:
+        # Shard spans entire array → one file per array.
+        # Must be a multiple of the inner chunk size.
+        shard_first = ((data.shape[0] + first_dim - 1) // first_dim) * first_dim
+        shards = (shard_first, *data.shape[1:])
+        arr = group.create_array(
+            path, shape=data.shape, dtype=data.dtype, chunks=chunks, shards=shards
+        )
+        arr[:] = data
+    elif _zarr.__version__.startswith("2"):
+        group.create_dataset(path, data=data, chunks=chunks)
+    else:
+        # zarr v3 library with zarr_format=2 — no sharding
+        arr = group.create_array(path, shape=data.shape, dtype=data.dtype, chunks=chunks)
+        arr[:] = data
+
+
 def write_id_arrays(
     geff_store: StoreLike,
     node_ids: np.ndarray,
@@ -337,8 +404,8 @@ def write_id_arrays(
         )
 
     geff_root = setup_zarr_group(geff_store, zarr_format)
-    geff_root[_path.NODE_IDS] = node_ids
-    geff_root[_path.EDGE_IDS] = edge_ids
+    _write_zarr_array(geff_root, _path.NODE_IDS, node_ids)
+    _write_zarr_array(geff_root, _path.EDGE_IDS, edge_ids)
 
 
 def write_props_arrays(
@@ -412,10 +479,10 @@ def write_props_arrays(
             data = None
 
         prop_group = props_group.create_group(prop)
-        prop_group[_path.VALUES] = values
+        _write_zarr_array(prop_group, _path.VALUES, values)
         if missing is not None:
-            prop_group[_path.MISSING] = missing
+            _write_zarr_array(prop_group, _path.MISSING, missing)
         if data is not None:
-            prop_group[_path.DATA] = data
+            _write_zarr_array(prop_group, _path.DATA, data)
 
     return metadata

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
+import zarr
 
 from geff import _path
 from geff._typing import PropDictNpArray
@@ -339,8 +340,6 @@ def _write_zarr_array(
         path: The path within the group.
         data: The numpy array to write.
     """
-    import zarr as _zarr
-
     if data.shape[0] == 0:
         group[path] = data
         return
@@ -360,7 +359,8 @@ def _write_zarr_array(
             path, shape=data.shape, dtype=data.dtype, chunks=chunks, shards=shards
         )
         arr[:] = data
-    elif _zarr.__version__.startswith("2"):
+    # this is more an API thing than a zarr spec version
+    elif zarr.__version__.startswith("2"):
         group.create_dataset(path, data=data, chunks=chunks)
     else:
         # zarr v3 library with zarr_format=2 — no sharding

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -315,12 +315,13 @@ def _compute_first_dim_chunk(shape: tuple[int, ...], itemsize: int) -> int:
 
     Trailing dimensions are kept whole so only the first dimension is chunked.
     """
+    first_dim = shape[0] if len(shape) > 0 else 1
     row_bytes = int(np.prod(shape[1:])) * itemsize if len(shape) > 1 else itemsize
     n_rows = _TARGET_CHUNK_BYTES // max(row_bytes, 1)
     # Round down to nearest power of two
     if n_rows >= 1:
         n_rows = 1 << (n_rows.bit_length() - 1)
-    return max(1, min(shape[0], n_rows))
+    return max(1, min(first_dim, n_rows))
 
 
 def _write_zarr_array(

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -322,7 +322,7 @@ def _compute_first_dim_chunk(shape: tuple[int, ...], itemsize: int) -> int:
 
 
 def _write_zarr_array(
-    group: Any,
+    group: zarr.Group,
     path: str,
     data: np.ndarray,
 ) -> None:

--- a/packages/geff/src/geff/core_io/_base_write.py
+++ b/packages/geff/src/geff/core_io/_base_write.py
@@ -8,6 +8,7 @@ import numpy as np
 from geff import _path
 from geff._typing import PropDictNpArray
 from geff.core_io._utils import (
+    _detect_zarr_spec_version,
     check_for_geff,
     construct_var_len_props,
     default_for_value,
@@ -347,11 +348,8 @@ def _write_zarr_array(
     first_dim = _compute_first_dim_chunk(data.shape, data.dtype.itemsize)
     chunks = (first_dim, *data.shape[1:])
 
-    use_sharding = (
-        not _zarr.__version__.startswith("2")
-        and hasattr(group, "metadata")
-        and getattr(group.metadata, "zarr_format", 2) == 3
-    )
+    zarr_version = _detect_zarr_spec_version(group)
+    use_sharding = True if zarr_version is not None and zarr_version >= 3 else False
 
     if use_sharding:
         # Shard spans entire array → one file per array.

--- a/packages/geff/tests/test_core_io/test_base_read.py
+++ b/packages/geff/tests/test_core_io/test_base_read.py
@@ -226,6 +226,38 @@ def test_read_edge_props() -> None:
     _ = NxBackend.construct(**in_memory_geff)
 
 
+def test_build_w_masked_nodes_varlength() -> None:
+    """Regression test: varlength props must survive node masking.
+
+    The varlength DATA array is a flat concatenation of all elements and cannot
+    be indexed by a per-node boolean mask.  _load_prop_to_memory must load DATA
+    in full and rely on the per-node offsets stored in VALUES for deserialization.
+    """
+    store, memory_geff = create_mock_geff(
+        node_id_dtype="uint8",
+        node_axis_dtypes={"position": "double", "time": "uint8"},
+        extra_edge_props={"score": "float64"},
+        directed=True,
+        include_varlength=True,
+    )
+
+    reader = GeffReader(store)
+    reader.read_node_props(["var_length"])
+
+    n_nodes = reader.nodes.shape[0]
+    node_mask = np.zeros(n_nodes, dtype=bool)
+    node_mask[: n_nodes // 2] = True
+
+    in_memory_geff = reader.build(node_mask=node_mask)
+
+    expected = memory_geff["node_props"]["var_length"]["values"][node_mask]
+    actual = in_memory_geff["node_props"]["var_length"]["values"]
+
+    assert len(actual) == len(expected)
+    for exp, act in zip(expected, actual, strict=True):
+        np.testing.assert_array_equal(exp, act)
+
+
 def test_read_to_memory():
     # Mostly testing that conditionals run correctly since functionality is tested elsewhere
     store, _attrs = create_simple_2d_geff()

--- a/packages/geff/tests/test_core_io/test_base_read.py
+++ b/packages/geff/tests/test_core_io/test_base_read.py
@@ -226,6 +226,32 @@ def test_read_edge_props() -> None:
     _ = NxBackend.construct(**in_memory_geff)
 
 
+def test_build_w_empty_node_mask() -> None:
+    """All-False node mask triggers the len(indices)==0 branch in _load_zarr_subset."""
+    store, _memory_geff = create_mock_geff(
+        node_id_dtype="uint8",
+        node_axis_dtypes={"position": "double", "time": "uint8"},
+        extra_edge_props={"score": "float64"},
+        directed=True,
+    )
+
+    reader = GeffReader(store)
+    reader.read_node_props(["z", "t"])
+
+    n_nodes = reader.nodes.shape[0]
+    node_mask = np.zeros(n_nodes, dtype=bool)  # select no nodes
+
+    in_memory_geff = reader.build(node_mask=node_mask)
+
+    assert len(in_memory_geff["node_ids"]) == 0
+    assert len(in_memory_geff["edge_ids"]) == 0
+    for prop_dict in in_memory_geff["node_props"].values():
+        assert len(prop_dict["values"]) == 0
+
+    # make sure graph dict can be ingested
+    _ = NxBackend.construct(**in_memory_geff)
+
+
 def test_build_w_masked_nodes_varlength() -> None:
     """Regression test: varlength props must survive node masking.
 


### PR DESCRIPTION
Hi @cmalinmayor 

# Proposed Change

Optimizes zarr I/O in `core_io` by replacing boolean-mask indexing with `oindex` integer indexing for reads, and adding explicit chunking with zarr v3 sharding for writes.

While profiling `tracksdata`, I noticed two performance issues:

1. `_load_prop_to_memory` converts boolean masks to Python lists via `mask.tolist()` before indexing zarr arrays. For sparse selections (e.g. 5 nodes out of 8674) this is ~7x slower than using integer indices with `oindex`, because zarr has to process the entire boolean array instead of just reading the relevant chunks.

2. No explicit chunking when writing arrays — zarr's auto-chunking splits trailing dimensions unnecessarily. For example, `edge_ids` with shape `(189870, 2)` gets chunked as `(47468, 1)`, putting each column in a separate chunk.

Also fixes a bug: the per-node boolean mask was applied to the varlength `DATA` array, which is a flat 1D concatenation with a completely different length. This crashes on zarr v3 with `VindexInvalidSelectionError`. The DATA array must always be loaded in full since deserialization uses byte offsets from VALUES.

### Benchmarks

Dataset: BF-C2DL-HSC/01 (8674 nodes, 189870 edges)

**`reader.build()` selecting 5 nodes:**

| Version | Time |
|---------|------|
| Before (`mask.tolist`) | ~155 ms |
| After (`oindex`) | ~21 ms |

**File count on zarr v3 write:**

| Version | Files on disk |
|---------|--------------|
| Before (auto-chunking) | 119 |
| After (sharding) | 67 |

**Chunking examples:**

| Array | Before | After |
|-------|--------|-------|
| `edge_ids` (189870, 2) uint64 | (47468, **1**) | (189870, **2**) |
| `bbox` (8674, 6) int64 | (4337, 6) | (8674, 6) |
| `mask/data` (4192807,) uint64 | (131026,) | (1048576,) |

# Types of Changes

- Bugfix (non-breaking change which fixes an issue)
- New feature or enhancement

Which topics does your change affect?

- Core io

# Checklist

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING) docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).

# Further Comments

The change is split into two commits:

1. **Reading**: adds `_load_zarr_subset()` using `oindex` and fixes the varlength DATA bug. The boolean mask API of `_load_prop_to_memory` and `build()` is unchanged — the conversion to integer indices happens internally.

2. **Writing**: adds `_write_zarr_array()` that chunks only along the first dimension (power-of-two size, ~8 MiB target). On zarr v3 it uses sharding so each array becomes a single file with sub-chunks inside. On zarr v2 it just uses the larger explicit chunks. Empty arrays fall back to direct assignment.

All 116 `test_core_io` tests pass.
I haven't added new tests yet — the existing masked-read tests (`test_build_w_masked_nodes`, `test_load_prop_into_memory`, etc.) already exercise the new code paths since the public API is unchanged.
Happy to add targeted benchmarks or edge-case tests if needed.