### PR TITLE
Fix error in conversion of 3D Cell Tracking Challenge data

### DIFF
--- a/packages/geff/pyproject.toml
+++ b/packages/geff/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=2.1; python_version >= '3.13'",
     "numcodecs>=0.13",
-    "numcodecs>=0.13,<0.16; python_version == '3.10'", # TODO: remove pin once the 16 release is stable
+    "numcodecs>=0.13,<0.16; python_version > '3.10,<=3.11'", # TODO: remove pin once the 16 release is stable
     "numcodecs>=0.15; python_version >= '3.13'", # TODO: remove pin once the 16 release is stable
 ]
 

--- a/packages/geff/src/geff/convert/_ctc.py
+++ b/packages/geff/src/geff/convert/_ctc.py
@@ -135,11 +135,10 @@ def from_ctc_to_geff(
 
     for t, filepath in enumerate(sorted_files):
         frame = tifffile.imread(filepath)
+        if frame.ndim == 3 and "z" not in node_props:
+            node_props["z"] = []
 
         if segmentation_store is not None and segm_array is None:
-            if frame.ndim == 3:
-                node_props["z"] = []
-
             # created in first iteration
             if tczyx:
                 n_1_padding = (1,) * (5 - frame.ndim - 1)  # forcing data to be (T, C, Z, Y, X)

--- a/packages/geff/tests/test_convert/test_ctc.py
+++ b/packages/geff/tests/test_convert/test_ctc.py
@@ -24,6 +24,7 @@ from geff.core_io import read_to_memory
 def create_mock_data(
     tmp_path: Path,
     is_gt: bool,
+    is_3d: bool = False,
     v2: bool = False,  # generates a slightly different dataset
 ) -> Path:
     """
@@ -35,6 +36,13 @@ def create_mock_data(
             / \\     |
     t=2    2   5     9
     """
+    if is_3d:
+        # for 3D example data, we created a different function to avoid littering this one with
+        # if-statements. But please keep the mock graph structure of both in sync!
+        if v2:
+            raise ValueError("v2=True not implemented for 3D data")
+        return _create_mock_data_3d(tmp_path, is_gt)
+
     mod_value = 9 if not v2 else 10
 
     labels = np.zeros((3, 10, 10), dtype=np.uint16)
@@ -70,16 +78,62 @@ def create_mock_data(
     return tmp_path
 
 
+def _create_mock_data_3d(tmp_path: Path, is_gt: bool) -> Path:
+    """
+    mock graph is:
+
+    t=0      1       7
+             |       |
+    t=1      1       |
+            / \\     |
+    t=2    2   5     9
+    """
+
+    labels = np.zeros((3, 10, 10, 10), dtype=np.uint16)
+
+    labels[0, 1, 3, 3] = 1
+    labels[0, 2, 8, 8] = 7
+
+    labels[1, 2, 3, 4] = 1
+
+    labels[2, 3, 2, 3] = 5
+    labels[2, 2, 4, 5] = 2
+    labels[2, 4, 8, 9] = 9
+
+    fmt = "man_track{:03d}.tif" if is_gt else "mask{:03d}.tif"
+
+    for t in range(labels.shape[0]):
+        tifffile.imwrite(
+            tmp_path / fmt.format(t),
+            labels[t],
+            compression="LZW",
+        )
+
+    tracks_file = tmp_path / ("man_track.txt" if is_gt else "res_track.txt")
+    # track_id, start, end, parent_id
+    tracks_table = [[1, 0, 1, 0], [2, 2, 2, 1], [5, 2, 2, 1], [7, 0, 0, 0], [9, 2, 2, 7]]
+
+    np.savetxt(
+        tracks_file,
+        tracks_table,
+        fmt="%d",
+    )
+
+    return tmp_path
+
+
 @pytest.mark.parametrize("is_gt", [True, False])
+@pytest.mark.parametrize("is_3d", [True, False])
 @pytest.mark.parametrize("tczyx", [True, False])
 class Test_ctc_to_geff:
     def test_basic(
         self,
         tmp_path: Path,
         is_gt: bool,
+        is_3d: bool,
         tczyx: bool,
     ) -> None:
-        ctc_path = create_mock_data(tmp_path, is_gt)
+        ctc_path = create_mock_data(tmp_path, is_gt, is_3d=is_3d)
         geff_path = tmp_path / "little.geff"
 
         from_ctc_to_geff(
@@ -204,9 +258,10 @@ class Test_ctc_to_geff:
         self,
         tmp_path: Path,
         is_gt: bool,
+        is_3d: bool,
         tczyx: bool,
     ):
-        ctc_path = create_mock_data(tmp_path, is_gt)
+        ctc_path = create_mock_data(tmp_path, is_gt, is_3d=is_3d)
         geff_path = tmp_path / "little.geff"
         segm_path = tmp_path / "segm.zarr"
 
@@ -239,13 +294,14 @@ class Test_ctc_to_geff:
         assert metadata.track_node_props == {"tracklet": "tracklet_id"}
         assert metadata.related_objects is not None
         assert metadata.related_objects[0] == RelatedObject(
-            type="labels", label_prop="tracklet_id", path="../segm.zarr"
+            type="labels", label_prop="tracklet_id", path=os.path.join("..", "segm.zarr")
         )
 
     def test_seg_to_store(
         self,
         tmp_path: Path,
         is_gt: bool,
+        is_3d: bool,
         tczyx: bool,
     ):
         ctc_path = create_mock_data(tmp_path, is_gt)
@@ -286,18 +342,19 @@ class Test_ctc_to_geff:
         assert metadata.track_node_props == {"tracklet": "tracklet_id"}
         assert metadata.related_objects is not None
         assert metadata.related_objects[0] == RelatedObject(
-            type="labels", label_prop="tracklet_id", path="../segm.zarr"
+            type="labels", label_prop="tracklet_id", path=os.path.join("..", "segm.zarr")
         )
 
     def test_seg_to_bad_store(
         self,
         tmp_path: Path,
         is_gt: bool,
+        is_3d: bool,
         tczyx: bool,
     ):
         # Finding the relative path won't work with a memory store and should issue a warning
 
-        ctc_path = create_mock_data(tmp_path, is_gt)
+        ctc_path = create_mock_data(tmp_path, is_gt, is_3d=is_3d)
         geff_path = tmp_path / "little.geff"
         store = zarr.storage.MemoryStore()
 


### PR DESCRIPTION
Hi all,

This pull request fixes an issue with the conversion from tracking data in the Cell Tracking Challenge (CTC) format to GEFF. I ran into this issue when creating some example data to test GEFF support for OrganoidTracker.

The command:

    geff convert-ctc E:\path\to\Fluo-N3DH-CE\01_GT\TRA E:\path\to\Fluo-N3DH-CE-01.geff

The error:

```
Traceback (most recent call last)
 D:\Git\geff\packages\geff\src\geff\_cli.py:96 in convert_ctc

    93 │   ):
    94 │   │   raise ValueError("'input_image_dir' and 'output_image_path' must be provided together")
    95 │
 >  96 │   from_ctc_to_geff(
    97 │   │   ctc_path=ctc_path,
    98 │   │   geff_path=geff_path,
    99 │   │   segmentation_store=segm_path,

 D:\Git\geff\packages\geff\src\geff\convert\_ctc.py:174 in from_ctc_to_geff

   171 │   │   │   node_props["t"].append(t)
   172 │   │   │   # using y,x for 2d and z,y,x for 3d
   173 │   │   │   for c, v in zip(("x", "y", "z"), obj.centroid[::-1], strict=False):
 > 174 │   │   │   │   node_props[c].append(v)
   175 │   │   │
   176 │   │   │   if tracklet_id not in tracks:
   177 │   │   │   │   tracks[tracklet_id] = []

KeyError: 'z'
```

# Proposed Change
When specifically converting 3D tracking data from the CTC format to GEFF, while not converting segmentations, the conversion would fail. This pull request fixes the issue by also initializing the `node_props["z"]` array if the segmentation store is None.

Simply moving the `if frame.ndim == 3:` check outside the `segm_array` initialization code doesn't work, as then the program would re-initialize `node_props["z"]` over and over again for every time point. Instead, a check has been added such that `node_props["z"]` is only initialized if it doesn't exist yet.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)

Which topics does your change affect? Delete those that do not apply.
- Convert

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [developer/contributing](https://github.com/live-image-tracking-tools/geff/blob/main/CONTRIBUTING.md) docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [ ] I have written docstrings and checked that they render correctly by looking at the docs preview (link left as a comment on the PR).  ***N/A***

## If you changed the specification
N/A

## If you have added or changed an implementation
N/A

# Further Comments
I'm not really experienced with such complex tests, so please check if this design is OK. There was an additional small error in the tests that made them fail on Windows (there the path is `..\\something` instead of `../something`), which I fixed too.

Thanks!