### PR TITLE
Bump spec bound to include 1.2

### DIFF
--- a/packages/geff/pyproject.toml
+++ b/packages/geff/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "geff-spec<1.2",
+    "geff-spec<1.3",
     "typer>=0.14.0",
     "zarr>=2.18,<4",
     "pydantic>=2.11",


### PR DESCRIPTION
In preparation for geff release 1.3.0.1.2